### PR TITLE
Load and diagnose packaged configuration projection

### DIFF
--- a/explorer-rx-module/src/hiconic/rx/explorer/processing/platformreflection/PlatformReflectionProcessor.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/processing/platformreflection/PlatformReflectionProcessor.java
@@ -170,6 +170,7 @@ public class PlatformReflectionProcessor extends AbstractDispatchingServiceProce
 
 	private File confFolder = null;
 	private File classpathResourcesFolder;
+	private File packagedConfFolder;
 	private File dataFolder;
 
 	private StreamPipeFactory streamPipeFactory;
@@ -856,13 +857,14 @@ public class PlatformReflectionProcessor extends AbstractDispatchingServiceProce
 		try {
 			ConfigurationFolder hd = ConfigurationFolder.T.create();
 
-			if (confFolder != null || classpathResourcesFolder != null) {
+			if (confFolder != null || classpathResourcesFolder != null || packagedConfFolder != null) {
 
 				String filename = "conf-" + now(fileDateTimeFormatter) + ".zip";
 
 				Map<String, File> map = new LinkedHashMap<>();
 				addFolderFiles(map, confFolder, "");
 				addFolderFiles(map, classpathResourcesFolder, "classpath-resources/");
+				addFolderFiles(map, packagedConfFolder, "packaged-conf/");
 
 				if (!map.isEmpty()) {
 					Resource callResource = Resource
@@ -1546,6 +1548,10 @@ public class PlatformReflectionProcessor extends AbstractDispatchingServiceProce
 	@Configurable
 	public void setClasspathResourcesFolder(File classpathResourcesFolder) {
 		this.classpathResourcesFolder = classpathResourcesFolder;
+	}
+	@Configurable
+	public void setPackagedConfFolder(File packagedConfFolder) {
+		this.packagedConfFolder = packagedConfFolder;
 	}
 	@Configurable
 	public void setDatabaseFolder(File databaseFolder) {

--- a/explorer-rx-module/src/hiconic/rx/explorer/wire/space/PlatformReflectionSpace.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/wire/space/PlatformReflectionSpace.java
@@ -61,6 +61,7 @@ public class PlatformReflectionSpace implements WireSpace {
 		bean.setZipPassword(null);
 		bean.setConfFolder(platformResources.confPath().toFile());
 		bean.setClasspathResourcesFolder(platformResources.rootPath().resolve("classpath-resources").toFile());
+		bean.setPackagedConfFolder(platformResources.rootPath().resolve("packaged-conf").toFile());
 		return bean;
 	}
 

--- a/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
+++ b/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
@@ -22,6 +22,10 @@ import static com.braintribe.console.ConsoleOutputs.text;
 import java.io.File;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -102,9 +106,17 @@ public class RxPlatform implements AutoCloseable {
 
 	private ClasspathIndex createClasspathIndex() {
 		String resourcesDir = systemProperties.classpathResourcesDir();
-		return resourcesDir == null || resourcesDir.isBlank()
-				? new ClasspathIndex()
-				: new ClasspathIndex(new File(resourcesDir).toPath());
+		if (resourcesDir == null || resourcesDir.isBlank())
+			return new ClasspathIndex();
+
+		List<ClasspathIndex.FilesystemSource> sources = new ArrayList<>();
+		sources.add(ClasspathIndex.filesystemSource(new File(resourcesDir).toPath(), ""));
+
+		Path packagedConfDir = systemProperties.appDir().toPath().resolve("packaged-conf");
+		if (Files.isDirectory(packagedConfDir))
+			sources.add(ClasspathIndex.filesystemSource(packagedConfDir, RxConfigurationConstants.CLASSPATH_CONF_PATH));
+
+		return new ClasspathIndex(sources);
 	}
 
 	public static Function<String, String> defaultSystemPropertyLookup() {


### PR DESCRIPTION
## Summary
- load the optional packaged-conf filesystem projection as canonical HICONIC-CONF resources
- preserve the complete classpath-resources fallback and IDE classpath behavior
- include packaged-conf in platform diagnostic archives

## Verification
- hc compile in reflex-platform and explorer-rx-module
- hc test in reflex-platform-test