### PR TITLE
Make demo log production opt in

### DIFF
--- a/log-reflection-demo-rx-module/src/hiconic/rx/log/reflection/demo/wire/space/LogReflectionDemoRxModuleSpace.java
+++ b/log-reflection-demo-rx-module/src/hiconic/rx/log/reflection/demo/wire/space/LogReflectionDemoRxModuleSpace.java
@@ -9,25 +9,44 @@ import hiconic.rx.module.api.wire.RxPlatformContract;
 
 @Managed
 public class LogReflectionDemoRxModuleSpace implements RxModuleContract {
+	private static final String ENABLED_EXPRESSION = "${LOG_REFLECTION_DEMO_ENABLED:-false}";
+	private static final String INTERVAL_EXPRESSION = "${LOG_REFLECTION_DEMO_INTERVAL_MILLIS:-750}";
 
 	@Import
 	private RxPlatformContract platform;
+	private boolean started;
 
 	@Override
 	public void onApplicationReady() {
-		producer().start();
+		if (enabled()) {
+			producer().start();
+			started = true;
+		}
 	}
 
 	@Override
 	public void onApplicationShutdown() {
-		producer().stop();
+		if (started)
+			producer().stop();
 	}
 
 	@Managed
 	private DemoLogProducer producer() {
 		DemoLogProducer bean = new DemoLogProducer();
 		bean.setScheduler(platform.execution().scheduledExecutorService());
-		bean.setIntervalMillis(750);
+		bean.setIntervalMillis(intervalMillis());
 		return bean;
+	}
+
+	private boolean enabled() {
+		return Boolean.parseBoolean(resolve(ENABLED_EXPRESSION));
+	}
+
+	private long intervalMillis() {
+		return Long.parseLong(resolve(INTERVAL_EXPRESSION));
+	}
+
+	private String resolve(String expression) {
+		return platform.configuration().propertyResolver().resolve(expression);
 	}
 }


### PR DESCRIPTION
## Summary
- keep the optional log-reflection demo module inert by default
- enable it explicitly with LOG_REFLECTION_DEMO_ENABLED=true
- allow the test interval to be controlled with LOG_REFLECTION_DEMO_INTERVAL_MILLIS

## Verification
- hc compile in log-reflection-demo-rx-module