### PR TITLE
Use classpath mirror only when assembled

### DIFF
--- a/reflex-app-resources/resources/bin/run
+++ b/reflex-app-resources/resources/bin/run
@@ -37,4 +37,9 @@ fi
 # REFLEX_OPTS remains an intentionally late, deployment-specific override/addition.
 read -r -a ENV_JVM_OPTIONS <<< "${REFLEX_OPTS:-}"
 
-"$JAVA_EXECUTABLE" "${PACKAGED_JVM_OPTIONS[@]}" "${ENV_JVM_OPTIONS[@]}" -Dreflex.app.dir="$INST_DIR" -Dreflex.launch.script="$LAUNCH_SCRIPT" -Dreflex.classpath.resources.dir="$INST_DIR/classpath-resources" -Djava.net.useSystemProxies=true -jar "$LIB_PATH/launch.jar" "$@"
+CLASSPATH_RESOURCES_OPTIONS=()
+if [ -d "$INST_DIR/classpath-resources" ]; then
+    CLASSPATH_RESOURCES_OPTIONS+=("-Dreflex.classpath.resources.dir=$INST_DIR/classpath-resources")
+fi
+
+"$JAVA_EXECUTABLE" "${PACKAGED_JVM_OPTIONS[@]}" "${ENV_JVM_OPTIONS[@]}" "${CLASSPATH_RESOURCES_OPTIONS[@]}" -Dreflex.app.dir="$INST_DIR" -Dreflex.launch.script="$LAUNCH_SCRIPT" -Djava.net.useSystemProxies=true -jar "$LIB_PATH/launch.jar" "$@"

--- a/reflex-app-resources/resources/bin/run.bat
+++ b/reflex-app-resources/resources/bin/run.bat
@@ -31,6 +31,11 @@ if exist "%JVM_OPTIONS_FILE%" (
     for /f "usebackq eol=# delims=" %%O in ("%JVM_OPTIONS_FILE%") do set "PACKAGED_JVM_OPTIONS=!PACKAGED_JVM_OPTIONS! %%O"
 )
 
-%JAVA_EXECUTABLE% %PACKAGED_JVM_OPTIONS% %REFLEX_OPTS% -Dreflex.app.dir="%~dp0\.." -Dreflex.launch.script=%LAUNCH_SCRIPT% -Dreflex.classpath.resources.dir="%~dp0\..\classpath-resources" -Djava.net.useSystemProxies=true -jar "%LIB_PATH%\launch.jar" %*
+set "CLASSPATH_RESOURCES_OPTION="
+if exist "%~dp0\..\classpath-resources\" (
+    set "CLASSPATH_RESOURCES_OPTION=-Dreflex.classpath.resources.dir=%~dp0\..\classpath-resources"
+)
+
+%JAVA_EXECUTABLE% %PACKAGED_JVM_OPTIONS% %REFLEX_OPTS% %CLASSPATH_RESOURCES_OPTION% -Dreflex.app.dir="%~dp0\.." -Dreflex.launch.script=%LAUNCH_SCRIPT% -Djava.net.useSystemProxies=true -jar "%LIB_PATH%\launch.jar" %*
 
 endlocal


### PR DESCRIPTION
## Summary

- enable filesystem classpath resources only when the assembled mirror directory exists
- retain the regular JAR classpath for SDK tools and other non-assembled RX launchers
- apply the same behavior to Unix and Windows launchers

## Regression

The prior launcher always set `reflex.classpath.resources.dir`. This broke `hc-build` in the SDK Docker because SDK tools have no assembled `classpath-resources` directory.

## Verification

- shell syntax validated with `bash -n`
- launcher fixture without a mirror omits the property
- launcher fixture with a mirror includes the property