### PR TITLE
Resolve indexed configuration resources from assembled mirrors

### DIFF
--- a/reflex-module-api/src/hiconic/rx/module/api/wire/RxConfigurationContract.java
+++ b/reflex-module-api/src/hiconic/rx/module/api/wire/RxConfigurationContract.java
@@ -16,6 +16,7 @@ package hiconic.rx.module.api.wire;
 import com.braintribe.gm.model.reason.Maybe;
 import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.resource.api.ResourceHandle;
 import com.braintribe.wire.api.space.WireSpace;
 
 import hiconic.rx.module.api.config.PropertyResolver;
@@ -32,6 +33,14 @@ public interface RxConfigurationContract extends WireSpace {
 	 * If an explicit configuration cannot be found a default initialized instance of the configType will be returned.
 	 */
 	<C extends GenericEntity> Maybe<C> readConfig(EntityType<C> configType);
+
+	/**
+	 * Resolves an indexed classpath resource by its canonical path.
+	 * <p>
+	 * In an assembled application this transparently resolves against the filesystem mirror, while IDE launches continue to resolve against the
+	 * real classpath.
+	 */
+	ResourceHandle indexedClasspathResource(String path);
 	
 	PropertyResolver propertyResolver();
 }

--- a/reflex-platform-test/src/hiconic/rx/platform/wire/space/RxConfigurationSpaceTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/wire/space/RxConfigurationSpaceTest.java
@@ -1,0 +1,48 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.wire.space;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
+
+public class RxConfigurationSpaceTest {
+
+	@Test
+	public void resolvesCanonicalIndexedResource() throws Exception {
+		var index = new ClasspathIndex(getClass().getClassLoader());
+		var resource = RxConfigurationSpace.resolveIndexedClasspathResource(index, "/HICONIC-RESOURCES/test/hello.txt");
+
+		try (var in = resource.asStream()) {
+			assertThat(new String(in.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("private hello\n");
+		}
+	}
+
+	@Test
+	public void rejectsMissingAndUnsafePaths() {
+		var index = new ClasspathIndex(getClass().getClassLoader());
+
+		assertThatThrownBy(() -> RxConfigurationSpace.resolveIndexedClasspathResource(index, "missing/resource"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("not found");
+		assertThatThrownBy(() -> RxConfigurationSpace.resolveIndexedClasspathResource(index, "../outside"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Invalid");
+	}
+}

--- a/reflex-platform/src/hiconic/rx/platform/wire/space/RxConfigurationSpace.java
+++ b/reflex-platform/src/hiconic/rx/platform/wire/space/RxConfigurationSpace.java
@@ -13,13 +13,17 @@
 // ============================================================================
 package hiconic.rx.platform.wire.space;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 import com.braintribe.common.attribute.AttributeContext;
 import com.braintribe.gm.config.yaml.ModeledYamlConfiguration;
+import com.braintribe.gm.config.yaml.index.ClasspathEntry;
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
 import com.braintribe.gm.model.reason.Maybe;
 import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.resource.api.ResourceHandle;
 import com.braintribe.wire.api.annotation.Import;
 import com.braintribe.wire.api.annotation.Managed;
 
@@ -29,6 +33,7 @@ import hiconic.rx.platform.conf.RxPropertyResolver;
 import hiconic.rx.platform.models.RxCmdResolverManager;
 import hiconic.rx.platform.models.RxConfiguredModels;
 import hiconic.rx.platform.models.RxModelConfigurations;
+import hiconic.rx.platform.processing.resource.RxResourcesBuilding.RxUrlResourcesBuilder;
 import hiconic.rx.platform.wire.contract.RxPlatformConfigContract;
 
 @Managed
@@ -55,6 +60,38 @@ public class RxConfigurationSpace implements RxConfigurationContract {
 	@Override
 	public <C extends GenericEntity> Maybe<C> readConfig(EntityType<C> configType) {
 		return modeledConfiguration().configReasoned(configType);
+	}
+
+	@Override
+	public ResourceHandle indexedClasspathResource(String path) {
+		return resolveIndexedClasspathResource(platformConfig.classpathIndex(), path);
+	}
+
+	static ResourceHandle resolveIndexedClasspathResource(ClasspathIndex classpathIndex, String path) {
+		String normalizedPath = normalizeClasspathPath(path);
+		List<ClasspathEntry> entries = classpathIndex.forPrefix(normalizedPath).stream()
+				.filter(entry -> entry.path.equals(normalizedPath))
+				.toList();
+
+		if (entries.isEmpty())
+			throw new IllegalArgumentException("Indexed classpath resource not found: " + normalizedPath);
+		if (entries.size() > 1)
+			throw new IllegalArgumentException("Indexed classpath resource is ambiguous: " + normalizedPath + " (origins: "
+					+ entries.stream().map(entry -> entry.origin).toList() + ")");
+
+		return new RxUrlResourcesBuilder(entries.get(0).url);
+	}
+
+	private static String normalizeClasspathPath(String path) {
+		if (path == null || path.isBlank())
+			throw new IllegalArgumentException("Classpath resource path must not be empty");
+
+		String normalized = path.replace('\\', '/');
+		while (normalized.startsWith("/"))
+			normalized = normalized.substring(1);
+		if (normalized.isEmpty() || normalized.contains("../") || normalized.equals(".."))
+			throw new IllegalArgumentException("Invalid classpath resource path: " + path);
+		return normalized;
 	}
 
 	@Managed

--- a/web-server-rx-module/src/hiconic/platform/reflex/web_server/processing/SslConfig.java
+++ b/web-server-rx-module/src/hiconic/platform/reflex/web_server/processing/SslConfig.java
@@ -20,11 +20,12 @@ import java.security.KeyStore;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 
+import hiconic.rx.module.api.wire.RxConfigurationContract;
 import hiconic.rx.web.server.model.config.WebServerConfiguration;
 
 public record SslConfig(int port, SSLContext sslContext) {
 
-	public static SslConfig buildFromConfig(WebServerConfiguration config) {
+	public static SslConfig buildFromConfig(WebServerConfiguration config, RxConfigurationContract configuration) {
 		Integer port = config.getSslPort();
 		if (port == null)
 			return null;
@@ -42,7 +43,7 @@ public record SslConfig(int port, SSLContext sslContext) {
 		try {
 			// Load the keystore
 			KeyStore keyStore = KeyStore.getInstance("PKCS12");
-			try (var keystoreStream = openKeyStore(certPath)) {
+			try (var keystoreStream = openKeyStore(certPath, configuration)) {
 			    keyStore.load(keystoreStream, password.toCharArray());
 			}
 
@@ -60,7 +61,7 @@ public record SslConfig(int port, SSLContext sslContext) {
         return new SslConfig(port, sslContext);
 	}
 
-	private static InputStream openKeyStore(String path) throws Exception {
+	private static InputStream openKeyStore(String path, RxConfigurationContract configuration) throws Exception {
 		if (!path.startsWith("classpath:"))
 			return new FileInputStream(path);
 
@@ -68,11 +69,6 @@ public record SslConfig(int port, SSLContext sslContext) {
 		while (resourcePath.startsWith("/"))
 			resourcePath = resourcePath.substring(1);
 
-		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-		InputStream stream = classLoader.getResourceAsStream(resourcePath);
-		if (stream == null)
-			throw new IllegalArgumentException("SSL key store classpath resource not found: " + resourcePath);
-
-		return stream;
+		return configuration.indexedClasspathResource(resourcePath).asStream();
 	}
 }

--- a/web-server-rx-module/src/hiconic/platform/reflex/web_server/wire/space/WebServerRxModuleSpace.java
+++ b/web-server-rx-module/src/hiconic/platform/reflex/web_server/wire/space/WebServerRxModuleSpace.java
@@ -512,7 +512,7 @@ public class WebServerRxModuleSpace implements RxModuleContract, WebServerContra
 
 	@Managed
 	private Box<SslConfig> sslConfigBox() {
-		return Box.of(SslConfig.buildFromConfig(configuration()));
+		return Box.of(SslConfig.buildFromConfig(configuration(), platform.configuration()));
 	}
 
 	@Managed


### PR DESCRIPTION
## Summary
- expose canonical indexed classpath resource resolution through the RX configuration contract
- transparently use the assembled filesystem mirror or the real IDE classpath
- load SSL keystores through that normalized resource path
- cover canonical, missing, and unsafe resource paths

## Verification
- reflex-module-api install
- reflex-platform install
- web-server-rx-module compile
- reflex-platform-test: all tests successful

This closes the clean-image startup gap where resource-only configuration JARs are pruned after mirroring but the SSL keystore was still opened directly through ClassLoader.