### PR TITLE
Assemble and validate modeled configuration

### DIFF
--- a/configuration-assembly-processing-test/.gitignore
+++ b/configuration-assembly-processing-test/.gitignore
@@ -1,0 +1,3 @@
+/build
+/dist
+/classes

--- a/configuration-assembly-processing-test/build.xml
+++ b/configuration-assembly-processing-test/build.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns:bt="antlib:com.braintribe.build.ant.tasks" basedir="." default="test">
+	<bt:import artifact="com.braintribe.devrock.ant:unit-test-ant-script#1.0" useCase="DEVROCK"/>
+</project>

--- a/configuration-assembly-processing-test/pom.xml
+++ b/configuration-assembly-processing-test/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>hiconic.platform.reflex</groupId>
+		<artifactId>parent</artifactId>
+		<version>[1.0,1.1)</version>
+	</parent>
+	<artifactId>configuration-assembly-processing-test</artifactId>
+	<version>1.0.1</version>
+	<dependencies>
+		<dependency>
+			<groupId>com.braintribe.testing</groupId>
+			<artifactId>unit-test-deps</artifactId>
+			<version>${V.com.braintribe.testing}</version>
+		</dependency>
+		<dependency>
+			<groupId>hiconic.platform.reflex</groupId>
+			<artifactId>configuration-assembly-processing</artifactId>
+			<version>${V.hiconic.platform.reflex}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMainTest.java
+++ b/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMainTest.java
@@ -1,0 +1,53 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import static com.braintribe.testing.junit.assertions.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ConfigurationAssemblyMainTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void assemblesAnEmptyApplicationUsingOnlyFilesystemInputs() throws Exception {
+		Path application = temporaryFolder.newFolder("application").toPath();
+		Files.createDirectories(application.resolve("classpath-resources"));
+		Files.createDirectories(application.resolve("conf"));
+
+		int status = ConfigurationAssemblyMain.run(new String[] { "--application-dir", application.toString() });
+
+		assertThat(status).isZero();
+		assertThat(application.resolve("packaged-conf/effective")).isDirectory();
+		assertThat(application.resolve("packaged-conf/assembly-report.yaml")).isRegularFile();
+	}
+
+	@Test
+	public void rejectsIncompleteAndUnknownArguments() {
+		assertThat(ConfigurationAssemblyMain.run(new String[0])).isEqualTo(2);
+		assertThat(ConfigurationAssemblyMain.run(new String[] {
+				"--application-dir", temporaryFolder.getRoot().getAbsolutePath(),
+				"--unknown", "value"
+		})).isEqualTo(2);
+	}
+}

--- a/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationImportDeclarationsTest.java
+++ b/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationImportDeclarationsTest.java
@@ -1,0 +1,335 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import static com.braintribe.testing.junit.assertions.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
+
+import hiconic.rx.platform.configuration.model.SampleConfiguration;
+
+public class ConfigurationImportDeclarationsTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void mergesEquivalentDeclarationsAndReportsUndeclaredVariables() throws Exception {
+		Path root = temporaryFolder.newFolder("mirror").toPath();
+		artifact(root, "base", """
+				imports:
+				  - name: DB_HOST
+				    required: true
+				    description: Database host
+				""");
+		artifact(root, "overlay", """
+				imports:
+				  - name: DB_HOST
+				    required: true
+				    description: Database host
+				  - name: DB_PASSWORD
+				    required: true
+				    confidential: true
+				""");
+
+		var declarationsMaybe = ConfigurationImportDeclarations.read(new ClasspathIndex(root));
+
+		assertThat(declarationsMaybe.isSatisfied()).isTrue();
+		ConfigurationImportDeclarations declarations = declarationsMaybe.get();
+		assertThat(declarations.names()).containsExactlyInAnyOrder("DB_HOST", "DB_PASSWORD");
+
+		ConfigurationAssemblyReport report = declarations.report(List.of("DB_PASSWORD", "MISSING", "reflex.app.dir"));
+		assertThat(report.getUnresolvedVariables()).containsExactly("DB_PASSWORD", "MISSING", "reflex.app.dir");
+		assertThat(report.getUndeclaredVariables()).containsExactly("MISSING");
+		assertThat(report.getPlatformVariables()).containsExactly("reflex.app.dir");
+	}
+
+	@Test
+	public void rejectsIncompatibleDeclarations() throws Exception {
+		Path root = temporaryFolder.newFolder("conflict").toPath();
+		artifact(root, "base", """
+				imports:
+				  - name: DB_HOST
+				    required: true
+				""");
+		artifact(root, "overlay", """
+				imports:
+				  - name: DB_HOST
+				    required: false
+				""");
+
+		assertThat(ConfigurationImportDeclarations.read(new ClasspathIndex(root)).isUnsatisfied()).isTrue();
+	}
+
+	@Test
+	public void resolvesClosedPropertiesAndTracesSymbolicAliasesToExternalLeaves() {
+		var propertiesMaybe = SymbolicConfigurationProperties.analyze(Map.of(
+				"DB_DEFAULT_PORT", "5432",
+				"DB_DEFAULT_NAME", "proventem",
+				"DB_DEFAULT_URL", "jdbc:postgresql://${DB_DEFAULT_HOST}:${DB_DEFAULT_PORT}/${DB_DEFAULT_NAME}",
+				"HTTP_PORT", "8080"));
+
+		assertThat(propertiesMaybe.isSatisfied()).isTrue();
+		SymbolicConfigurationProperties properties = propertiesMaybe.get();
+		assertThat(properties.resolveKnown("HTTP_PORT").get()).isEqualTo("8080");
+		assertThat(properties.resolveKnown("DB_DEFAULT_URL").isUnsatisfied()).isTrue();
+		assertThat(properties.externalLeaves(Set.of("DB_DEFAULT_URL"))).containsExactly("DB_DEFAULT_HOST");
+	}
+
+	@Test
+	public void rejectsPropertyCycles() {
+		var propertiesMaybe = SymbolicConfigurationProperties.analyze(Map.of(
+				"A", "${B}",
+				"B", "${A}"));
+
+		assertThat(propertiesMaybe.isUnsatisfied()).isTrue();
+	}
+
+	@Test
+	public void tracesDecryptFunctionsWithoutEvaluatingSecretsAtBuildTime() {
+		var propertiesMaybe = SymbolicConfigurationProperties.analyze(Map.of(
+				"RX_DECRYPT_SECRET", "${TRIBEFIRE_DECRYPT_SECRET}",
+				"ENCRYPTED_PASSWORD", "${PASSWORD_CIPHER}",
+				"LITERAL_PASSWORD", "${decrypt('cipher-text')}",
+				"INDIRECT_PASSWORD", "${decrypt(${ENCRYPTED_PASSWORD})}"));
+
+		assertThat(propertiesMaybe.isSatisfied()).isTrue();
+		SymbolicConfigurationProperties properties = propertiesMaybe.get();
+		assertThat(properties.resolveKnown("LITERAL_PASSWORD").isUnsatisfied()).isTrue();
+		assertThat(properties.externalLeaves(Set.of("LITERAL_PASSWORD")))
+				.containsExactly("TRIBEFIRE_DECRYPT_SECRET");
+		assertThat(properties.externalLeaves(Set.of("INDIRECT_PASSWORD")))
+				.containsExactlyInAnyOrder("TRIBEFIRE_DECRYPT_SECRET", "PASSWORD_CIPHER");
+	}
+
+	@Test
+	public void rejectsUnsupportedPropertyFunctions() {
+		var propertiesMaybe = SymbolicConfigurationProperties.analyze(Map.of(
+				"VALUE", "${unknown('parameter')}"));
+
+		assertThat(propertiesMaybe.isUnsatisfied()).isTrue();
+		assertThat(propertiesMaybe.whyUnsatisfied().stringify()).contains("Unsupported configuration property operation: unknown");
+	}
+
+	@Test
+	public void assemblesModeledLayersAndValidatesExternalLeaves() throws Exception {
+		Path root = temporaryFolder.newFolder("assembly").toPath();
+		artifact(root, "base", Map.of(
+				"HICONIC-CONF/properties.yaml", """
+						DB_DEFAULT_PORT: "5432"
+						DB_DEFAULT_NAME: "proventem"
+						DB_DEFAULT_URL: "jdbc:postgresql://${DB_DEFAULT_HOST}:${DB_DEFAULT_PORT}/${DB_DEFAULT_NAME}"
+						""",
+				"HICONIC-CONF/sample-configuration.yaml", """
+						endpoint: "${DB_DEFAULT_URL}"
+						label: base
+						""",
+				"HICONIC-CONF/unknown-configuration.yaml", """
+						value: retained
+						""",
+				ConfigurationImportDeclarations.RESOURCE_PATH, """
+						imports:
+						  - name: DB_DEFAULT_HOST
+						    required: true
+						"""));
+		artifact(root, "overlay", Map.of(
+				"HICONIC-CONF/sample-configuration.overlay-10.yaml", """
+						label: overlay
+						"""));
+
+		Path conf = temporaryFolder.newFolder("conf").toPath();
+		Files.writeString(conf.resolve("sample-configuration.local-20.yaml"), "label: filesystem\n", StandardCharsets.UTF_8);
+
+		var assemblyMaybe = new ModeledConfigurationAssembler(
+				new ClasspathIndex(root),
+				conf.toFile(),
+				"HICONIC-CONF",
+				List.of(SampleConfiguration.T))
+				.assemble();
+
+		assertThat(assemblyMaybe.isSatisfied()).isTrue();
+		ConfigurationAssembly assembly = assemblyMaybe.get();
+		assertThat(assembly.keys()).hasSize(1);
+		SampleConfiguration configuration = (SampleConfiguration) assembly.configurations().values().iterator().next();
+		assertThat(configuration.getLabel()).isEqualTo("filesystem");
+		assertThat(assembly.report().getUnresolvedVariables()).containsExactly("DB_DEFAULT_HOST");
+		assertThat(assembly.report().getUndeclaredVariables()).isEmpty();
+		assertThat(assembly.report().getResidualResources()).containsExactly("unknown-configuration.yaml");
+		assertThat(assembly.report().getAssembledConfigurations())
+				.containsExactly(SampleConfiguration.T.getTypeSignature());
+
+		Path output = temporaryFolder.newFolder("packaged-conf").toPath();
+		Path rawProjection = output.resolve("sample-artifact/sample-configuration.yaml");
+		Files.createDirectories(rawProjection.getParent());
+		Files.writeString(rawProjection, "raw: retained\n");
+		Path staleEffective = output.resolve("effective/stale-configuration.yaml");
+		Files.createDirectories(staleEffective.getParent());
+		Files.writeString(staleEffective, "stale: true\n");
+
+		var writeMaybe = ConfigurationAssemblyWriter.write(assembly, output);
+		assertThat(writeMaybe.isSatisfied()).isTrue();
+		String effectiveYaml = Files.readString(output.resolve("effective/sample-configuration.yaml"));
+		assertThat(effectiveYaml).contains("label: \"filesystem\"");
+		assertThat(effectiveYaml).contains("${DB_DEFAULT_URL}");
+		assertThat(staleEffective).doesNotExist();
+		assertThat(rawProjection).exists();
+		assertThat(output.resolve(ConfigurationAssemblyWriter.REPORT_FILE)).exists();
+	}
+
+	@Test
+	public void rejectsAnExternalLeafWhichNoArtifactDeclared() throws Exception {
+		Path root = temporaryFolder.newFolder("undeclared").toPath();
+		artifact(root, "base", Map.of(
+				"HICONIC-CONF/properties.yaml", """
+						DB_DEFAULT_URL: "jdbc:postgresql://${DB_DEFAULT_HOST}/proventem"
+						""",
+				"HICONIC-CONF/sample-configuration.yaml", """
+						endpoint: "${DB_DEFAULT_URL}"
+						"""));
+
+		var assemblyMaybe = new ModeledConfigurationAssembler(
+				new ClasspathIndex(root),
+				temporaryFolder.newFolder("empty-conf"),
+				"HICONIC-CONF",
+				List.of(SampleConfiguration.T))
+				.assemble();
+
+		assertThat(assemblyMaybe.isUnsatisfied()).isTrue();
+		assertThat(assemblyMaybe.value().report().getUndeclaredVariables()).containsExactly("DB_DEFAULT_HOST");
+	}
+
+	@Test
+	public void preservesUseCaseAsPartOfTheCanonicalConfigurationKey() throws Exception {
+		Path root = temporaryFolder.newFolder("use-case").toPath();
+		artifact(root, "worker", Map.of(
+				"HICONIC-CONF/sample-configuration~worker.yaml", """
+						label: worker
+						"""));
+
+		var assemblyMaybe = new ModeledConfigurationAssembler(
+				new ClasspathIndex(root),
+				temporaryFolder.newFolder("use-case-conf"),
+				"HICONIC-CONF",
+				List.of(SampleConfiguration.T))
+				.assemble();
+
+		assertThat(assemblyMaybe.isSatisfied()).isTrue();
+		ConfigurationKey key = assemblyMaybe.get().keys().iterator().next();
+		assertThat(key.useCase()).isEqualTo("worker");
+		assertThat(key.fileName()).isEqualTo("sample-configuration~worker.yaml");
+		assertThat(((SampleConfiguration) assemblyMaybe.get().configurations().get(key)).getLabel()).isEqualTo("worker");
+	}
+
+	@Test
+	public void rejectsAmbiguousAndMalformedModeledResourceNames() throws Exception {
+		Path root = temporaryFolder.newFolder("invalid-discovery").toPath();
+		artifact(root, "invalid", Map.of(
+				"HICONIC-CONF/sample-configuration.yaml", "label: value\n",
+				"HICONIC-CONF/sample-configuration~.yaml", "label: value\n"));
+
+		var assemblyMaybe = new ModeledConfigurationAssembler(
+				new ClasspathIndex(root),
+				temporaryFolder.newFolder("invalid-discovery-conf"),
+				"HICONIC-CONF",
+				List.of(SampleConfiguration.T,
+						hiconic.rx.platform.configuration.model.alternative.SampleConfiguration.T))
+				.assemble();
+
+		assertThat(assemblyMaybe.isUnsatisfied()).isTrue();
+		String reason = assemblyMaybe.whyUnsatisfied().stringify();
+		assertThat(reason).contains("Ambiguous modeled configuration resource");
+		assertThat(reason).contains("Malformed modeled configuration resource name");
+	}
+
+	@Test
+	public void reportsInvalidPropertyGraphsThroughTheAssemblyBoundary() throws Exception {
+		Path root = temporaryFolder.newFolder("cyclic-assembly").toPath();
+		artifact(root, "cycle", Map.of(
+				"HICONIC-CONF/properties.yaml", """
+						A: "${B}"
+						B: "${A}"
+						""",
+				"HICONIC-CONF/sample-configuration.yaml", """
+						endpoint: "${A}"
+						"""));
+
+		var assemblyMaybe = new ModeledConfigurationAssembler(
+				new ClasspathIndex(root),
+				temporaryFolder.newFolder("cyclic-assembly-conf"),
+				"HICONIC-CONF",
+				List.of(SampleConfiguration.T))
+				.assemble();
+
+		assertThat(assemblyMaybe.isUnsatisfied()).isTrue();
+		assertThat(assemblyMaybe.whyUnsatisfied().stringify()).contains("Cyclic configuration property reference");
+	}
+
+	@Test
+	public void reportsConflictingImportsThroughTheAssemblyBoundary() throws Exception {
+		Path root = temporaryFolder.newFolder("conflicting-import-assembly").toPath();
+		artifact(root, "first", """
+				imports:
+				  - name: DB_HOST
+				    required: true
+				""");
+		artifact(root, "second", """
+				imports:
+				  - name: DB_HOST
+				    required: false
+				""");
+
+		var assemblyMaybe = new ModeledConfigurationAssembler(
+				new ClasspathIndex(root),
+				temporaryFolder.newFolder("conflicting-import-assembly-conf"),
+				"HICONIC-CONF",
+				List.of(SampleConfiguration.T))
+				.assemble();
+
+		assertThat(assemblyMaybe.isUnsatisfied()).isTrue();
+		assertThat(assemblyMaybe.whyUnsatisfied().stringify()).contains("Incompatible declarations for configuration import");
+	}
+
+	private static void artifact(Path root, String artifact, String declarations) throws Exception {
+		artifact(root, artifact, Map.of(ConfigurationImportDeclarations.RESOURCE_PATH, declarations));
+	}
+
+	private static void artifact(Path root, String artifact, Map<String, String> resources) throws Exception {
+		Path artifactRoot = root.resolve(artifact);
+		Path metaInf = artifactRoot.resolve("META-INF");
+		Files.createDirectories(metaInf);
+		Files.writeString(metaInf.resolve("classpath-index.txt"),
+				String.join("\n", resources.keySet().stream().sorted().toList()) + "\n",
+				StandardCharsets.UTF_8);
+		Files.writeString(metaInf.resolve("classpath-origin.properties"), "artifactId=" + artifact + "\n", StandardCharsets.UTF_8);
+		for (Map.Entry<String, String> resource : resources.entrySet()) {
+			Path file = artifactRoot.resolve(resource.getKey());
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, resource.getValue(), StandardCharsets.UTF_8);
+		}
+	}
+}

--- a/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/model/SampleConfiguration.java
+++ b/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/model/SampleConfiguration.java
@@ -1,0 +1,31 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration.model;
+
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.EntityTypes;
+
+public interface SampleConfiguration extends GenericEntity {
+
+	EntityType<SampleConfiguration> T = EntityTypes.T(SampleConfiguration.class);
+
+	String getEndpoint();
+	void setEndpoint(String endpoint);
+
+	String getLabel();
+	void setLabel(String label);
+}

--- a/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/model/alternative/SampleConfiguration.java
+++ b/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/model/alternative/SampleConfiguration.java
@@ -1,0 +1,29 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration.model.alternative;
+
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.EntityTypes;
+
+/** Deliberately shares its short name with the primary test type. */
+public interface SampleConfiguration extends GenericEntity {
+
+	EntityType<SampleConfiguration> T = EntityTypes.T(SampleConfiguration.class);
+
+	String getValue();
+	void setValue(String value);
+}

--- a/configuration-assembly-processing/.gitignore
+++ b/configuration-assembly-processing/.gitignore
@@ -1,0 +1,3 @@
+/build
+/dist
+/classes

--- a/configuration-assembly-processing/build.xml
+++ b/configuration-assembly-processing/build.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns:bt="antlib:com.braintribe.build.ant.tasks" basedir="." default="install">
+	<bt:import artifact="com.braintribe.devrock.ant:library-ant-script#1.0" useCase="DEVROCK"/>
+</project>

--- a/configuration-assembly-processing/pom.xml
+++ b/configuration-assembly-processing/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>hiconic.platform.reflex</groupId>
+		<artifactId>parent</artifactId>
+		<version>[1.0,1.1)</version>
+	</parent>
+	<artifactId>configuration-assembly-processing</artifactId>
+	<version>1.0.1</version>
+	<dependencies>
+		<dependency>
+			<groupId>hiconic.platform.reflex</groupId>
+			<artifactId>reflex-platform</artifactId>
+			<version>${V.hiconic.platform.reflex}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.braintribe.gm</groupId>
+			<artifactId>configuration-assembly-model</artifactId>
+			<version>${V.com.braintribe.gm}</version>
+			<?tag asset?>
+		</dependency>
+	</dependencies>
+</project>

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssembly.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssembly.java
@@ -1,0 +1,45 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import java.util.List;
+import java.util.Map;
+
+import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
+import com.braintribe.model.generic.GenericEntity;
+
+/**
+ * Result of statically assembling the modeled part of an application's configuration.
+ * <p>
+ * This deliberately is a plain processing value rather than another persisted model. The report is modeled because it crosses the build/runtime
+ * boundary; the assembled entities already carry their own reflected types.
+ */
+public record ConfigurationAssembly(
+		Map<ConfigurationKey, GenericEntity> configurations,
+		Map<String, String> rawProperties,
+		Map<String, String> resolvedProperties,
+		ConfigurationAssemblyReport report) {
+
+	public ConfigurationAssembly {
+		configurations = Map.copyOf(configurations);
+		rawProperties = Map.copyOf(rawProperties);
+		resolvedProperties = Map.copyOf(resolvedProperties);
+	}
+
+	public List<ConfigurationKey> keys() {
+		return configurations.keySet().stream().sorted().toList();
+	}
+}

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMain.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMain.java
@@ -1,0 +1,109 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
+import com.braintribe.gm.model.reason.Maybe;
+
+/**
+ * Narrow application-classpath launcher for static configuration assembly.
+ */
+public final class ConfigurationAssemblyMain {
+
+	private ConfigurationAssemblyMain() {
+	}
+
+	public static void main(String[] args) {
+		int status = run(args);
+		if (status != 0)
+			System.exit(status);
+	}
+
+	static int run(String[] args) {
+		try {
+			Map<String, String> options = parse(args);
+			Path applicationDirectory = requiredPath(options, "--application-dir");
+			Path resourcesDirectory = optionPath(options, "--classpath-resources",
+					applicationDirectory.resolve("classpath-resources"));
+			Path outputDirectory = optionPath(options, "--output-dir", applicationDirectory.resolve("packaged-conf"));
+			Path confDirectory = optionPath(options, "--conf-dir", applicationDirectory.resolve("conf"));
+			if (!options.isEmpty())
+				throw new IllegalArgumentException("Unknown configuration assembly option(s): " + String.join(", ", options.keySet()));
+
+			ClasspathIndex index = Files.isDirectory(resourcesDirectory)
+					? new ClasspathIndex(resourcesDirectory)
+					: new ClasspathIndex();
+
+			Maybe<ConfigurationAssembly> assemblyMaybe =
+					new ModeledConfigurationAssembler(index, confDirectory.toFile()).assemble();
+			if (assemblyMaybe.isUnsatisfied()) {
+				System.err.println(assemblyMaybe.whyUnsatisfied().stringify());
+				return 1;
+			}
+
+			Maybe<Void> writeMaybe = ConfigurationAssemblyWriter.write(assemblyMaybe.get(), outputDirectory);
+			if (writeMaybe.isUnsatisfied()) {
+				System.err.println(writeMaybe.whyUnsatisfied().stringify());
+				return 1;
+			}
+
+			ConfigurationAssembly assembly = assemblyMaybe.get();
+			System.out.println("Assembled " + assembly.configurations().size() + " modeled configuration(s) into " + outputDirectory);
+			if (!assembly.report().getResidualResources().isEmpty())
+				System.out.println("Retained " + assembly.report().getResidualResources().size() + " residual configuration resource(s)");
+			return 0;
+		} catch (IllegalArgumentException e) {
+			System.err.println(e.getMessage());
+			System.err.println("Usage: ConfigurationAssemblyMain --application-dir <path> "
+					+ "[--classpath-resources <path>] [--conf-dir <path>] [--output-dir <path>]");
+			return 2;
+		}
+	}
+
+	private static Map<String, String> parse(String[] args) {
+		if (args.length % 2 != 0)
+			throw new IllegalArgumentException("Every configuration assembly option requires a value");
+
+		Map<String, String> result = new LinkedHashMap<>();
+		for (int i = 0; i < args.length; i += 2) {
+			String name = args[i];
+			if (!name.startsWith("--"))
+				throw new IllegalArgumentException("Unexpected configuration assembly argument: " + name);
+			if (result.put(name, args[i + 1]) != null)
+				throw new IllegalArgumentException("Duplicate configuration assembly option: " + name);
+		}
+		return result;
+	}
+
+	private static Path requiredPath(Map<String, String> options, String name) {
+		String value = options.remove(name);
+		if (value == null || value.isBlank())
+			throw new IllegalArgumentException("Missing required configuration assembly option " + name);
+		return Path.of(value).toAbsolutePath().normalize();
+	}
+
+	private static Path optionPath(Map<String, String> options, String name, Path defaultValue) {
+		String value = options.remove(name);
+		if (value == null || value.isBlank())
+			return defaultValue.toAbsolutePath().normalize();
+		return Path.of(value).toAbsolutePath().normalize();
+	}
+}

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyWriter.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyWriter.java
@@ -1,0 +1,116 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+
+import com.braintribe.codec.marshaller.api.GmSerializationOptions;
+import com.braintribe.codec.marshaller.api.OutputPrettiness;
+import com.braintribe.codec.marshaller.api.PlaceholderSupport;
+import com.braintribe.codec.marshaller.api.TypeExplicitness;
+import com.braintribe.codec.marshaller.api.TypeExplicitnessOption;
+import com.braintribe.codec.marshaller.yaml.YamlMarshaller;
+import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
+import com.braintribe.gm.config.yaml.YamlConfigurations;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reasons;
+import com.braintribe.gm.model.reason.config.ConfigurationError;
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.reflection.EntityType;
+
+/**
+ * Writes the canonical modeled closure and validates every written entity by parsing and serializing it again.
+ */
+public final class ConfigurationAssemblyWriter {
+
+	public static final String EFFECTIVE_DIRECTORY = "effective";
+	public static final String REPORT_FILE = "assembly-report.yaml";
+
+	private ConfigurationAssemblyWriter() {
+	}
+
+	public static Maybe<Void> write(ConfigurationAssembly assembly, Path packagedConfDirectory) {
+		Path effectiveDirectory = packagedConfDirectory.resolve(EFFECTIVE_DIRECTORY);
+		try {
+			recreateDirectory(effectiveDirectory);
+
+			for (Map.Entry<ConfigurationKey, GenericEntity> entry : assembly.configurations().entrySet()) {
+				String yaml = serialize(entry.getValue(), entry.getKey().type());
+				Maybe<Void> roundtripMaybe = verifyRoundtrip(entry.getKey(), yaml);
+				if (roundtripMaybe.isUnsatisfied())
+					return roundtripMaybe;
+				Files.writeString(effectiveDirectory.resolve(entry.getKey().fileName()), yaml, StandardCharsets.UTF_8);
+			}
+
+			String reportYaml = serialize(assembly.report(), ConfigurationAssemblyReport.T);
+			Files.writeString(packagedConfDirectory.resolve(REPORT_FILE), reportYaml, StandardCharsets.UTF_8);
+			return Maybe.complete(null);
+		} catch (IOException | UncheckedIOException e) {
+			return Reasons.build(ConfigurationError.T)
+					.text("Could not write assembled configuration to " + packagedConfDirectory + ": " + e)
+					.toMaybe();
+		}
+	}
+
+	private static void recreateDirectory(Path directory) throws IOException {
+		if (Files.exists(directory)) {
+			try (var paths = Files.walk(directory)) {
+				for (Path path : paths.sorted(Comparator.reverseOrder()).toList())
+					Files.delete(path);
+			}
+		}
+		Files.createDirectories(directory);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static Maybe<Void> verifyRoundtrip(ConfigurationKey key, String yaml) {
+		Maybe<? extends GenericEntity> readMaybe = YamlConfigurations.read((EntityType) key.type())
+				.placeholders()
+				.from(new StringReader(yaml));
+		if (readMaybe.isUnsatisfied())
+			return Reasons.build(ConfigurationError.T)
+					.text("Could not parse assembled configuration " + key.displayName())
+					.cause(readMaybe.whyUnsatisfied())
+					.toMaybe();
+
+		String repeated = serialize(readMaybe.get(), key.type());
+		if (!yaml.equals(repeated))
+			return ConfigurationError.create("Configuration serialization is not stable for " + key.displayName()).asMaybe();
+
+		return Maybe.complete(null);
+	}
+
+	private static String serialize(GenericEntity entity, EntityType<?> type) {
+		GmSerializationOptions options = GmSerializationOptions.deriveDefaults()
+				.inferredRootType(type)
+				.outputPrettiness(OutputPrettiness.high)
+				.set(PlaceholderSupport.class, true)
+				.set(TypeExplicitnessOption.class, TypeExplicitness.polymorphic)
+				.build();
+
+		StringWriter writer = new StringWriter();
+		new YamlMarshaller().marshall(writer, entity, options);
+		return writer.toString();
+	}
+}

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationKey.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationKey.java
@@ -1,0 +1,45 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import com.braintribe.model.generic.reflection.EntityType;
+
+/** Canonical identity of one modeled configuration and optional use-case. */
+public record ConfigurationKey(EntityType<?> type, String useCase, String baseName) implements Comparable<ConfigurationKey> {
+
+	public ConfigurationKey {
+		useCase = useCase == null ? "" : useCase;
+	}
+
+	public String fileName() {
+		return baseName + (useCase.isEmpty() ? "" : "~" + useCase) + ".yaml";
+	}
+
+	public String displayName() {
+		return type.getTypeSignature() + (useCase.isEmpty() ? "" : " [" + useCase + "]");
+	}
+
+	@Override
+	public int compareTo(ConfigurationKey other) {
+		int result = baseName.compareTo(other.baseName);
+		if (result != 0)
+			return result;
+		result = useCase.compareTo(other.useCase);
+		if (result != 0)
+			return result;
+		return type.getTypeSignature().compareTo(other.type.getTypeSignature());
+	}
+}

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ModeledConfigurationAssembler.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ModeledConfigurationAssembler.java
@@ -1,0 +1,245 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import static com.braintribe.utils.lcd.StringTools.camelCaseToSocialDistancingCase;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.braintribe.codec.marshaller.yaml.YamlMarshaller;
+import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
+import com.braintribe.gm.config.yaml.ModeledYamlConfiguration;
+import com.braintribe.gm.config.yaml.api.PartiallyResolvedConfiguration;
+import com.braintribe.gm.config.yaml.index.ClasspathEntry;
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reasons;
+import com.braintribe.gm.model.reason.config.ConfigurationError;
+import com.braintribe.model.generic.GMF;
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.Model;
+import com.braintribe.model.meta.GmMetaModel;
+
+import hiconic.rx.platform.loading.RxPropertiesLoader;
+
+/**
+ * Builds and validates the static, modeled configuration closure of an application.
+ * <p>
+ * It intentionally reuses the runtime loaders, ordering and merge implementation. Programmatic configuration registrations are outside this static
+ * phase and therefore cannot accidentally initialize application wiring during a build.
+ */
+public final class ModeledConfigurationAssembler {
+
+	public static final String DEFAULT_CLASSPATH_CONF_PATH = "HICONIC-CONF/";
+	private static final Set<String> INFRASTRUCTURE_YAML = Set.of("properties");
+
+	private final ClasspathIndex classpathIndex;
+	private final File configFolder;
+	private final String classpathConfPath;
+	private final Collection<EntityType<?>> candidateTypes;
+
+	public ModeledConfigurationAssembler(ClasspathIndex classpathIndex, File configFolder) {
+		this(classpathIndex, configFolder, DEFAULT_CLASSPATH_CONF_PATH, packagedEntityTypes());
+	}
+
+	/** Constructor with an explicit type universe, primarily useful for deterministic isolated tests. */
+	public ModeledConfigurationAssembler(ClasspathIndex classpathIndex, File configFolder, String classpathConfPath,
+			Collection<EntityType<?>> candidateTypes) {
+		this.classpathIndex = Objects.requireNonNull(classpathIndex, "classpathIndex");
+		this.configFolder = Objects.requireNonNull(configFolder, "configFolder");
+		this.classpathConfPath = normalizeClasspathPath(classpathConfPath);
+		this.candidateTypes = List.copyOf(candidateTypes);
+	}
+
+	public Maybe<ConfigurationAssembly> assemble() {
+		var errors = Reasons.aggregatorForceWrap(() -> ConfigurationError.create("Could not assemble modeled application configuration"));
+
+		Maybe<Map<String, String>> rawPropertiesMaybe = RxPropertiesLoader.loadLayered(configFolder, classpathConfPath, "properties",
+				new YamlMarshaller(), classpathIndex);
+		if (rawPropertiesMaybe.isUnsatisfied())
+			return rawPropertiesMaybe.whyUnsatisfied().asMaybe();
+
+		Maybe<SymbolicConfigurationProperties> symbolicPropertiesMaybe = SymbolicConfigurationProperties.analyze(rawPropertiesMaybe.get());
+		if (symbolicPropertiesMaybe.isUnsatisfied())
+			errors.accept(symbolicPropertiesMaybe.whyUnsatisfied());
+		SymbolicConfigurationProperties symbolicProperties = symbolicPropertiesMaybe.value();
+		if (symbolicProperties == null)
+			return errors.get().asMaybe();
+
+		Maybe<ConfigurationImportDeclarations> declarationsMaybe = ConfigurationImportDeclarations.read(classpathIndex);
+		if (declarationsMaybe.isUnsatisfied())
+			errors.accept(declarationsMaybe.whyUnsatisfied());
+		ConfigurationImportDeclarations declarations = declarationsMaybe.value();
+		if (declarations == null)
+			return errors.get().asMaybe();
+
+		Map<String, List<EntityType<?>>> typesByBaseName = indexTypes(candidateTypes);
+		Discovery discovery = discover(typesByBaseName, errors);
+
+		ModeledYamlConfiguration loader = new ModeledYamlConfiguration();
+		loader.setClasspathIndex(classpathIndex);
+		loader.setClasspathConfPath(classpathConfPath);
+		loader.setConfigFolder(configFolder);
+		loader.setExternalReasonedPropertyLookup(symbolicProperties::resolveKnown);
+
+		Map<ConfigurationKey, GenericEntity> configurations = new LinkedHashMap<>();
+		Set<String> unresolvedAliases = new LinkedHashSet<>();
+
+		for (ConfigurationKey key : discovery.keys()) {
+			Maybe<? extends PartiallyResolvedConfiguration<? extends GenericEntity>> configMaybe =
+					load(loader, key);
+			if (configMaybe.isUnsatisfied()) {
+				errors.accept(configMaybe.whyUnsatisfied());
+				continue;
+			}
+
+			PartiallyResolvedConfiguration<? extends GenericEntity> partial = configMaybe.get();
+			configurations.put(key, partial.configuration());
+			unresolvedAliases.addAll(partial.unresolvedVariables());
+		}
+
+		Set<String> externalLeaves = symbolicProperties.externalLeaves(unresolvedAliases);
+		ConfigurationAssemblyReport report = declarations.report(externalLeaves);
+		report.setAssembledConfigurations(configurations.keySet().stream().sorted().map(ConfigurationKey::displayName).toList());
+		report.setResidualResources(discovery.residualResources());
+
+		if (!report.getUndeclaredVariables().isEmpty())
+			errors.accept(ConfigurationError.create("Undeclared configuration imports: "
+					+ String.join(", ", report.getUndeclaredVariables())));
+
+		ConfigurationAssembly assembly = new ConfigurationAssembly(configurations, symbolicProperties.rawProperties(),
+				symbolicProperties.resolvedProperties(), report);
+		if (errors.hasReason())
+			return Maybe.incomplete(assembly, errors.get());
+
+		return Maybe.complete(assembly);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static Maybe<? extends PartiallyResolvedConfiguration<? extends GenericEntity>> load(ModeledYamlConfiguration loader,
+			ConfigurationKey key) {
+		return loader.staticConfigPartiallyReasoned((EntityType) key.type(), key.useCase());
+	}
+
+	private Discovery discover(Map<String, List<EntityType<?>>> typesByBaseName,
+			com.braintribe.gm.model.reason.ReasonAggregator<ConfigurationError> errors) {
+		Set<String> resourceNames = new LinkedHashSet<>();
+		String prefix = classpathConfPath;
+		for (ClasspathEntry entry : classpathIndex.forPrefix(prefix)) {
+			String relative = entry.path.substring(prefix.length());
+			if (!relative.contains("/"))
+				resourceNames.add(relative);
+		}
+
+		if (configFolder.isDirectory()) {
+			File[] files = configFolder.listFiles(File::isFile);
+			if (files != null)
+				for (File file : files)
+					resourceNames.add(file.getName());
+		}
+
+		Set<ConfigurationKey> keys = new LinkedHashSet<>();
+		List<String> residual = new ArrayList<>();
+		for (String resourceName : resourceNames.stream().sorted().toList()) {
+			if (!resourceName.endsWith(".yaml"))
+				continue;
+
+			ParsedName parsed = parse(resourceName, errors);
+			if (parsed == null)
+				continue;
+			if (INFRASTRUCTURE_YAML.contains(parsed.baseName()))
+				continue;
+
+			List<EntityType<?>> matches = typesByBaseName.get(parsed.baseName());
+			if (matches == null || matches.isEmpty()) {
+				residual.add(resourceName);
+				continue;
+			}
+
+			if (matches.size() > 1) {
+				errors.accept(ConfigurationError.create("Ambiguous modeled configuration resource [" + resourceName + "] matches "
+						+ matches.stream().map(EntityType::getTypeSignature).sorted().toList()));
+				continue;
+			}
+
+			keys.add(new ConfigurationKey(matches.get(0), parsed.useCase(), parsed.baseName()));
+		}
+
+		return new Discovery(keys.stream().sorted().toList(), residual.stream().sorted().toList());
+	}
+
+	private static ParsedName parse(String resourceName,
+			com.braintribe.gm.model.reason.ReasonAggregator<ConfigurationError> errors) {
+		String stem = resourceName.substring(0, resourceName.length() - ".yaml".length());
+		int disambiguator = stem.indexOf('.');
+		String identity = disambiguator < 0 ? stem : stem.substring(0, disambiguator);
+		int useCaseSeparator = identity.indexOf('~');
+		String baseName = useCaseSeparator < 0 ? identity : identity.substring(0, useCaseSeparator);
+		String useCase = useCaseSeparator < 0 ? "" : identity.substring(useCaseSeparator + 1);
+		boolean malformed = baseName.isBlank()
+				|| useCaseSeparator >= 0 && (useCase.isBlank() || useCase.indexOf('~') >= 0);
+		if (malformed) {
+			errors.accept(ConfigurationError.create("Malformed modeled configuration resource name [" + resourceName + "]"));
+			return null;
+		}
+		return new ParsedName(baseName, useCase);
+	}
+
+	private static Map<String, List<EntityType<?>>> indexTypes(Collection<EntityType<?>> types) {
+		Map<String, List<EntityType<?>>> result = new LinkedHashMap<>();
+		types.stream().sorted(Comparator.comparing(EntityType::getTypeSignature)).forEach(type -> {
+			String baseName = camelCaseToSocialDistancingCase(type.getShortName()).toLowerCase(Locale.ROOT);
+			result.computeIfAbsent(baseName, ignored -> new ArrayList<>()).add(type);
+		});
+		return result;
+	}
+
+	private static Collection<EntityType<?>> packagedEntityTypes() {
+		Set<EntityType<?>> result = new LinkedHashSet<>();
+		for (Model model : GMF.getTypeReflection().getPackagedModels()) {
+			GmMetaModel metaModel = model.getMetaModel();
+			metaModel.entityTypes()
+					.map(type -> GMF.getTypeReflection().findEntityType(type.getTypeSignature()))
+					.filter(Objects::nonNull)
+					.forEach(result::add);
+		}
+		return result;
+	}
+
+	private static String normalizeClasspathPath(String path) {
+		String result = Objects.requireNonNull(path, "classpathConfPath").replace('\\', '/');
+		while (result.startsWith("/"))
+			result = result.substring(1);
+		return result.endsWith("/") ? result : result + "/";
+	}
+
+	private record ParsedName(String baseName, String useCase) {
+	}
+
+	private record Discovery(List<ConfigurationKey> keys, List<String> residualResources) {
+	}
+}

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/SymbolicConfigurationProperties.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/SymbolicConfigurationProperties.java
@@ -1,0 +1,209 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reasons;
+import com.braintribe.gm.model.reason.config.ConfigurationError;
+import com.braintribe.gm.model.reason.config.PropertyNotFound;
+import com.braintribe.gm.model.reason.essential.ParseError;
+import com.braintribe.gm.model.reason.essential.UnsupportedOperation;
+import com.braintribe.model.generic.template.Template;
+import com.braintribe.model.generic.template.TemplateFragment;
+
+import hiconic.rx.module.api.common.RxPlatform;
+import hiconic.rx.platform.conf.RxPropertyExpression;
+
+/**
+ * Resolves the closed part of a layered property graph without consulting the build machine's environment.
+ * <p>
+ * A property which ultimately depends on an external leaf remains symbolic. Consumers can use {@link #externalLeaves(Collection)} to translate
+ * intermediate local property names back to the actual deployment imports.
+ */
+public final class SymbolicConfigurationProperties {
+
+	private final Map<String, String> rawProperties;
+	private final Map<String, Resolution> resolutions;
+
+	private SymbolicConfigurationProperties(Map<String, String> rawProperties, Map<String, Resolution> resolutions) {
+		this.rawProperties = Map.copyOf(rawProperties);
+		this.resolutions = Map.copyOf(resolutions);
+	}
+
+	public static Maybe<SymbolicConfigurationProperties> analyze(Map<String, String> rawProperties) {
+		Map<String, String> stableRawProperties = new LinkedHashMap<>(rawProperties);
+		Map<String, Resolution> resolutions = new LinkedHashMap<>();
+		var errors = Reasons.aggregatorForceWrap(() -> ConfigurationError.create("Invalid configuration property graph"));
+
+		for (String name : stableRawProperties.keySet()) {
+			Resolution resolution = resolve(name, stableRawProperties, resolutions, new ArrayDeque<>());
+			if (resolution.error() != null)
+				errors.accept(resolution.error());
+		}
+
+		SymbolicConfigurationProperties result = new SymbolicConfigurationProperties(stableRawProperties, resolutions);
+		if (errors.hasReason())
+			return Maybe.incomplete(result, errors.get());
+
+		return Maybe.complete(result);
+	}
+
+	/** Returns a value only when the complete local property expression is closed. */
+	public Maybe<String> resolveKnown(String name) {
+		Resolution resolution = resolutions.get(name);
+		if (resolution == null || !resolution.closed())
+			return PropertyNotFound.create(name).asMaybe();
+
+		if (resolution.error() != null)
+			return resolution.error().asMaybe();
+
+		return Maybe.complete(resolution.value());
+	}
+
+	/** Replaces local symbolic aliases with the undeclared external leaves on which they depend. */
+	public Set<String> externalLeaves(Collection<String> unresolvedNames) {
+		Set<String> result = new LinkedHashSet<>();
+		for (String name : unresolvedNames) {
+			Resolution resolution = resolutions.get(name);
+			if (resolution == null)
+				result.add(name);
+			else
+				result.addAll(resolution.externalLeaves());
+		}
+		return result;
+	}
+
+	public Map<String, String> rawProperties() {
+		return rawProperties;
+	}
+
+	public Map<String, String> resolvedProperties() {
+		Map<String, String> result = new LinkedHashMap<>();
+		resolutions.forEach((name, resolution) -> {
+			if (resolution.error() == null && resolution.closed())
+				result.put(name, resolution.value());
+		});
+		return result;
+	}
+
+	private static Resolution resolve(String name, Map<String, String> rawProperties, Map<String, Resolution> resolutions, Deque<String> stack) {
+		Resolution known = resolutions.get(name);
+		if (known != null)
+			return known;
+
+		if (stack.contains(name)) {
+			String cycle = String.join(" -> ", stack) + " -> " + name;
+			Resolution result = Resolution.error(ConfigurationError.create("Cyclic configuration property reference: " + cycle));
+			resolutions.put(name, result);
+			return result;
+		}
+
+		String rawValue = rawProperties.get(name);
+		if (rawValue == null)
+			return Resolution.external(name);
+
+		Template template;
+		try {
+			template = Template.parse(rawValue);
+		} catch (IllegalArgumentException e) {
+			Resolution result = Resolution.error(Reasons.build(ParseError.T)
+					.text("Could not parse configuration property [" + name + "]: " + e.getMessage())
+					.toReason());
+			resolutions.put(name, result);
+			return result;
+		}
+
+		stack.addLast(name);
+		StringBuilder value = new StringBuilder();
+		Set<String> externalLeaves = new LinkedHashSet<>();
+		com.braintribe.gm.model.reason.Reason error = null;
+		boolean closed = true;
+
+		for (TemplateFragment fragment : template.fragments()) {
+			if (!fragment.isPlaceholder()) {
+				value.append(fragment.getText());
+				continue;
+			}
+
+			Resolution nested = resolveExpression(fragment.getText(), rawProperties, resolutions, stack);
+			if (nested.error() != null) {
+				error = nested.error();
+				break;
+			}
+
+			if (nested.closed())
+				value.append(nested.value());
+			else {
+				closed = false;
+				externalLeaves.addAll(nested.externalLeaves());
+			}
+		}
+
+		stack.removeLast();
+		Resolution result = error == null
+				? new Resolution(closed ? value.toString() : null, Set.copyOf(externalLeaves), null, closed)
+				: Resolution.error(error);
+		resolutions.put(name, result);
+		return result;
+	}
+
+	private static Resolution resolveExpression(String expression, Map<String, String> rawProperties,
+			Map<String, Resolution> resolutions, Deque<String> stack) {
+		var functionCall = RxPropertyExpression.functionCall(expression);
+		if (functionCall.isEmpty())
+			return resolve(expression, rawProperties, resolutions, stack);
+
+		RxPropertyExpression.FunctionCall function = functionCall.get();
+		if (!function.name().equals("decrypt"))
+			return Resolution.error(Reasons.build(UnsupportedOperation.T)
+					.text("Unsupported configuration property operation: " + function.name())
+					.toReason());
+
+		Set<String> externalLeaves = new LinkedHashSet<>();
+		Resolution secret = resolve(RxPlatform.PROPERTY_DECRYPT_SECRET, rawProperties, resolutions, stack);
+		if (secret.error() != null)
+			return secret;
+		externalLeaves.addAll(secret.externalLeaves());
+
+		if (function.nestedProperty().isPresent()) {
+			Resolution parameter = resolve(function.nestedProperty().get(), rawProperties, resolutions, stack);
+			if (parameter.error() != null)
+				return parameter;
+			externalLeaves.addAll(parameter.externalLeaves());
+		}
+
+		// Even a fully closed decrypt expression deliberately remains symbolic at build time.
+		return new Resolution(null, Set.copyOf(externalLeaves), null, false);
+	}
+
+	private record Resolution(String value, Set<String> externalLeaves, com.braintribe.gm.model.reason.Reason error, boolean closed) {
+		private static Resolution external(String name) {
+			return new Resolution(null, Set.of(name), null, false);
+		}
+
+		private static Resolution error(com.braintribe.gm.model.reason.Reason error) {
+			return new Resolution(null, Set.of(), error, false);
+		}
+	}
+}

--- a/docs/configuration/configuration-assembly.md
+++ b/docs/configuration/configuration-assembly.md
@@ -60,12 +60,12 @@ Imports are declared in the separately modeled
 
 ```yaml
 imports:
-  DB_DEFAULT_HOST:
+  - name: DB_DEFAULT_HOST
     required: true
     confidential: false
     description: PostgreSQL host supplied by the deployment
 
-  DB_DEFAULT_PASSWORD:
+  - name: DB_DEFAULT_PASSWORD
     required: true
     confidential: true
     description: PostgreSQL password supplied by the deployment
@@ -89,8 +89,10 @@ The small declaration model belongs to a central GM
 the application-classpath assembler, artifact validators, runtime diagnostics
 and future tooling all need the same semantics without depending on the build
 system. The terminal assembler aggregates the artifact declarations into its
-assembly report. Runtime code consumes that report rather than rediscovering
-and reinterpreting the individual declarations.
+assembly report. During the backward-compatible rollout, runtime and build-time
+assembly use the same declaration reader over the indexed artifact resources.
+Once the effective view is authoritative, runtime may consume its aggregated
+report without changing import semantics.
 
 Semantics:
 
@@ -106,8 +108,44 @@ Semantics:
 - Defaults remain property definitions in `properties.yaml`; they are not
   duplicated in the import declaration.
 
-Platform-provided variables such as `reflex.app.dir` form a standard import
-set. Source-location variables such as `config.file` and `config.dir` require
+### Managed runtime binding
+
+An environment variable is not itself a configuration layer. In the managed
+regime, deployment values enter configuration through one explicit binding
+step:
+
+```text
+declared import
+  -> system property / environment lookup
+  -> managed raw-property map
+  -> normal property and modeled-configuration resolution
+```
+
+Only exact declared import names are looked up. A packaged or filesystem
+property of the same name takes precedence and can therefore satisfy a
+required import for local or test setups without consulting the host.
+System properties take precedence over environment variables when both supply
+the same declared import.
+
+Missing `required` imports fail application startup before module wiring.
+Missing optional imports remain absent. After binding, the runtime property
+resolver has no implicit system-property, environment-variable or
+`env.`-prefixed fallback: processors and configuration consumers observe only
+the managed property graph.
+
+For migration safety this strict mode is activated by the presence of at least
+one `META-INF/configuration-imports.yaml`. Existing applications without an
+import descriptor retain the legacy fallback behavior. An intentionally empty
+descriptor is therefore also a deliberate opt-in to managed properties.
+Direct users of `RxPropertyResolver` retain legacy behavior unless they
+explicitly enable its managed-only mode. The older
+`EnvironmentPropertiesContract` is not changed implicitly by this rollout; its
+eventual migration is a separately auditable step.
+
+Platform-provided variables such as `reflex.app.dir` form a separate standard
+input set. They remain symbolic but are reported as platform variables rather
+than deployment imports; an operator must not be told to supply them.
+Source-location variables such as `config.file` and `config.dir` require
 special handling because moving a configuration into the effective view must
 not silently change their meaning.
 
@@ -121,7 +159,7 @@ Modeled YAML already provides the required foundation:
 - the YAML marshaller can write these descriptors back as ordinary
   `${...}` expressions when `PlaceholderSupport` is enabled.
 
-The assembler must use a partial symbolic property evaluator rather than the
+The assembler uses a partial symbolic property evaluator rather than the
 strict runtime resolver. For example:
 
 ```yaml
@@ -130,16 +168,22 @@ DB_DEFAULT_NAME: "proventem"
 DB_DEFAULT_URL: "jdbc:postgresql://${DB_DEFAULT_HOST}:${DB_DEFAULT_PORT}/${DB_DEFAULT_NAME}"
 ```
 
-may become an expression equivalent to:
+is validated against the external leaf `DB_DEFAULT_HOST`, although the first
+writer deliberately preserves the named property boundary:
 
 ```yaml
-DB_DEFAULT_URL: "jdbc:postgresql://${DB_DEFAULT_HOST}:5432/proventem"
+endpoint: "${DB_DEFAULT_URL}"
 ```
 
-when `DB_DEFAULT_HOST` is an import.
+This retains the author’s named configuration abstraction while proving that
+its only external dependency is the declared import. Partial inlining to an
+equivalent expression such as
+`jdbc:postgresql://${DB_DEFAULT_HOST}:5432/proventem` is a possible later
+normalization, not a prerequisite for closure validation.
 
 The written result is parsed again and compared semantically with the
-assembled entity. This round trip is part of validation.
+assembled entity. It is then serialized again and must produce byte-identical
+canonical YAML. This round trip is part of validation.
 
 ## Configuration assembler SPI
 
@@ -184,9 +228,32 @@ The main class initializes application model reflection, the indexed resource
 view and the assembler registry. It does not start the web server or normal
 application lifecycle.
 
-This avoids mixing the build-tool classpath with the application classpath.
-The RX application Ant script only has to launch a forked Java process after
-dependencies and indexed resources have been materialized.
+The reusable implementation is carried by the regular
+`configuration-assembly-processing` dependency. Configuration aggregators
+propagate it naturally through setups to application terminals. This is
+intentional:
+
+- Maven `test` would misclassify configuration assembly as testing;
+- Maven `provided` is flat and would have to be repeated on every aggregator
+  and terminal;
+- neither scope expresses the required union of the application's runtime
+  graph and build-time processing;
+- the marginal runtime footprint is small because model reflection, modeled
+  configuration and YAML processing are already present;
+- the same processing is useful for runtime diagnostics and future
+  configuration reflection.
+
+The launcher remains a narrow `main(String[])` adapter with filesystem
+arguments. It introduces no modeled command API and contains no artifact
+resolution. This avoids mixing the build-tool classpath with the application
+classpath: the RX application Ant script only launches a forked Java process
+after dependencies and indexed resources have been materialized.
+
+The core implementation and launcher now exist and are tested independently
+of the application Ant script. Activating the launcher in application assembly
+is a separate rollout step: the runtime shadow/index representation must first
+ensure that an effective entry replaces, rather than supplements, its raw
+fragments.
 
 Configuration type discovery initially maps the canonical kebab-case filename
 to application entity short names:
@@ -261,6 +328,26 @@ The feature is additive:
 
 This permits incremental rollout per application while the assemblers and
 coverage become progressively stricter.
+
+## Implementation status
+
+The first hardened increment provides:
+
+- merged and conflict-checked import declarations;
+- closed local property evaluation and tracing of symbolic aliases to their
+  true external leaves;
+- discovery and typed merge of modeled configuration across classpath and
+  filesystem layers;
+- explicit use-case identity and ambiguity detection;
+- undeclared-import and property-cycle failures;
+- explicit separation of deployment imports and platform-supplied variables;
+- canonical effective YAML and assembly-report output;
+- placeholder-preserving parse/serialize stability checks;
+- a thin application-classpath command-line launcher.
+
+Residual materialization with full artifact provenance, runtime shadow-index
+activation, further configuration-family assemblers and Ant integration remain
+deliberately outside this increment.
 
 ## Proposed implementation sequence
 

--- a/docs/configuration/configuration-assembly.md
+++ b/docs/configuration/configuration-assembly.md
@@ -75,6 +75,23 @@ Import names are exact rather than pattern based. Import declarations from
 multiple configuration artifacts are merged. Incompatible declarations for
 the same name fail assembly.
 
+The declaration is artifact metadata, not runtime configuration. A
+configuration artifact packages it at the stable location
+`META-INF/configuration-imports.yaml`; a terminal application may contribute
+the same metadata. This is deliberately outside `HICONIC-CONF`, so the modeled
+configuration loader never mistakes the declaration for another configuration
+layer. The declaration must nevertheless travel with the artifact: keeping it
+only in a source repository or build configuration would make transitive
+terminal assembly incomplete.
+
+The small declaration model belongs to a central GM
+`configuration-assembly-model` artifact. It must not belong to an Ant task:
+the application-classpath assembler, artifact validators, runtime diagnostics
+and future tooling all need the same semantics without depending on the build
+system. The terminal assembler aggregates the artifact declarations into its
+assembly report. Runtime code consumes that report rather than rediscovering
+and reinterpreting the individual declarations.
+
 Semantics:
 
 - Internal properties must be fully resolvable from packaged properties and
@@ -258,4 +275,3 @@ coverage become progressively stricter.
    explicit compatibility switch.
 8. Enable it for one RX application and compare runtime semantics before
    making it the default.
-

--- a/docs/configuration/configuration-assembly.md
+++ b/docs/configuration/configuration-assembly.md
@@ -1,0 +1,261 @@
+# Reproducible Configuration Assembly
+
+## Motivation
+
+An RX application currently discovers and merges configuration from indexed
+classpath resources, the packaged filesystem mirror and the deployment
+`conf/` directory. This preserves composability, but a terminal application
+build does not yet prove that its packaged configuration is complete.
+Undeclared placeholders, incompatible fragments or missing sibling
+configuration can consequently remain undetected until the application starts
+or a particular configuration is first used.
+
+The terminal application build should therefore produce and validate an
+explicit static configuration closure. This closure is not a replacement for
+the source resources. It is a reproducible, inspectable view derived from them.
+
+The design has four goals:
+
+1. Validate configuration artifacts as early as possible.
+2. Prove at application build time that every non-imported property can be
+   resolved.
+3. Preserve legitimate deployment imports symbolically.
+4. Retain source provenance and backward-compatible runtime layering.
+
+## Configuration views
+
+An assembled application exposes three distinct views:
+
+```text
+application/
+  classpath-resources/     # immutable source/provenance mirror
+  packaged-conf/
+    effective/             # canonical static closure
+    residual/              # configuration assets without an assembler
+    assembly-report.yaml   # origins, imports, coverage and diagnostics
+  conf/                    # deployment overlays
+```
+
+`classpath-resources/` remains suitable for diagnostics and contains the
+unmodified indexed resources grouped by artifact. Successfully assembled
+source entries must, however, be shadowed in the runtime index so that the raw
+fragments and their effective result are not merged twice.
+
+`packaged-conf/effective/` contains one canonical result per configuration key
+where the corresponding assembler supports such a representation. A
+configuration key consists at least of configuration kind, modeled type and
+use case.
+
+Assets which cannot yet be assembled stay available below `residual/` with
+their artifact association. They are reported explicitly and retain their
+existing runtime behavior.
+
+## Explicit deployment imports
+
+Packaged properties are closed by default. A property placeholder may remain
+unresolved only when it is declared as a deployment import.
+
+Imports are declared in the separately modeled
+`configuration-imports.yaml`:
+
+```yaml
+imports:
+  DB_DEFAULT_HOST:
+    required: true
+    confidential: false
+    description: PostgreSQL host supplied by the deployment
+
+  DB_DEFAULT_PASSWORD:
+    required: true
+    confidential: true
+    description: PostgreSQL password supplied by the deployment
+```
+
+Import names are exact rather than pattern based. Import declarations from
+multiple configuration artifacts are merged. Incompatible declarations for
+the same name fail assembly.
+
+Semantics:
+
+- Internal properties must be fully resolvable from packaged properties and
+  platform-defined inputs.
+- Imports are symbolic leaves and are never accidentally resolved from the
+  build machine or CI environment.
+- Derived properties may be partially evaluated while retaining imported
+  variables.
+- Undeclared unresolved variables and property cycles are assembly errors.
+- `required` imports are validated early during runtime startup.
+- `confidential` imports are redacted in diagnostics and reports.
+- Defaults remain property definitions in `properties.yaml`; they are not
+  duplicated in the import declaration.
+
+Platform-provided variables such as `reflex.app.dir` form a standard import
+set. Source-location variables such as `config.file` and `config.dir` require
+special handling because moving a configuration into the effective view must
+not silently change their meaning.
+
+## Symbolic placeholder preservation
+
+Modeled YAML already provides the required foundation:
+
+- placeholder-aware unmarshalling can retain `Variable` and `Concatenation`
+  value descriptors;
+- unresolved imported variables can therefore survive merging;
+- the YAML marshaller can write these descriptors back as ordinary
+  `${...}` expressions when `PlaceholderSupport` is enabled.
+
+The assembler must use a partial symbolic property evaluator rather than the
+strict runtime resolver. For example:
+
+```yaml
+DB_DEFAULT_PORT: "5432"
+DB_DEFAULT_NAME: "proventem"
+DB_DEFAULT_URL: "jdbc:postgresql://${DB_DEFAULT_HOST}:${DB_DEFAULT_PORT}/${DB_DEFAULT_NAME}"
+```
+
+may become an expression equivalent to:
+
+```yaml
+DB_DEFAULT_URL: "jdbc:postgresql://${DB_DEFAULT_HOST}:5432/proventem"
+```
+
+when `DB_DEFAULT_HOST` is an import.
+
+The written result is parsed again and compared semantically with the
+assembled entity. This round trip is part of validation.
+
+## Configuration assembler SPI
+
+Different configuration families have different composition semantics. They
+are handled through a small SPI rather than one generic file merger:
+
+```text
+ConfigurationAssetAssembler
+  discover
+  classify
+  assemble
+  validate
+  write
+```
+
+Initial assemblers:
+
+1. layered properties;
+2. modeled YAML configuration;
+3. log-level configuration;
+4. Logback configuration.
+
+An assembler may produce one canonical file or a canonical ordered plan with
+fragments. Logback configuration, for example, should not be flattened when
+its natural semantics are an ordered application of fragments.
+
+Unknown assets are retained and reported. Strictness can later be raised once
+all intended configuration families have assemblers.
+
+## Execution on the application classpath
+
+Configuration assembly is executed by a dedicated main class on the real
+application classpath:
+
+```text
+java -cp <application-classpath> \
+  hiconic.rx.platform.configuration.ConfigurationAssemblyMain \
+  --application-dir <application-dir>
+```
+
+The main class initializes application model reflection, the indexed resource
+view and the assembler registry. It does not start the web server or normal
+application lifecycle.
+
+This avoids mixing the build-tool classpath with the application classpath.
+The RX application Ant script only has to launch a forked Java process after
+dependencies and indexed resources have been materialized.
+
+Configuration type discovery initially maps the canonical kebab-case filename
+to application entity short names:
+
+- no matching type leaves an explicitly reported residual;
+- multiple matching types are an assembly error;
+- the inferred type is used for typed unmarshalling and merging.
+
+A later configuration-type index or model marker can make discovery smaller
+and completely explicit without being a prerequisite for the first version.
+
+## Static and runtime-effective configuration
+
+The first implementation deliberately closes static configuration only:
+
+```text
+classpath fragments + packaged properties -> effective static configuration
+```
+
+Code-registered configuration contributions continue to be applied by the
+normal RX runtime at their existing stages. The assembly report states this
+coverage boundary and must not claim that the static result is the complete
+runtime state.
+
+A later phase may bootstrap the application only through configuration
+registration and include code contributions. That extension needs separate
+analysis because module wiring may create side effects and dependencies which
+do not belong in a build-time validation process.
+
+## Deployment replacement
+
+Normal files in `conf/` remain overlays. An emergency deployment can explicitly
+replace the packaged static configuration for one modeled type and use case
+with the reserved disambiguator:
+
+```text
+external-tools-configuration.replace-packaged.yaml
+```
+
+This suppresses the packaged static contribution for that key and begins the
+filesystem layer with the replacement file. It does not implicitly suppress
+later code-registered contributions.
+
+## Artifact-level validation
+
+The same assemblers can validate individual configuration artifacts before
+terminal application assembly:
+
+- indexed resources are syntactically valid;
+- canonical filenames map unambiguously to configuration types;
+- fragments can be unmarshalled with absent-property semantics;
+- locally defined property graphs contain no cycles;
+- import declarations are well formed;
+- placeholder serialization round trips correctly.
+
+Artifact validation cannot prove terminal completeness because dependencies
+and deployment imports are not yet closed. It nevertheless moves structural
+errors to the earliest meaningful build.
+
+## Backward-compatible rollout
+
+The feature is additive:
+
+- applications without an assembly report retain the existing loader;
+- raw classpath resources remain available for diagnostics;
+- residual configuration retains its current runtime behavior;
+- effective entries shadow only the raw entries from which they were built;
+- `conf/` overlays continue to work;
+- CX is unaffected;
+- configuration artifacts do not need to change before the first application
+  adopts assembly.
+
+This permits incremental rollout per application while the assemblers and
+coverage become progressively stricter.
+
+## Proposed implementation sequence
+
+1. Model `ConfigurationImports` and the assembly report.
+2. Implement the symbolic property graph and round-trip tests.
+3. Extract modeled YAML discovery, sorting and merging into a reusable
+   assembler.
+4. Test artifact-level validation with synthetic configuration artifacts.
+5. Test terminal closure with multiple artifacts, use cases and imports.
+6. Add residual handling and runtime shadowing.
+7. Invoke the assembly main from the RX application Ant script behind an
+   explicit compatibility switch.
+8. Enable it for one RX application and compare runtime semantics before
+   making it the default.
+

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -24,3 +24,5 @@ _Hiconic_ _Reflex_ (aka RX) aims to be a platform for __modeled micro-services__
 * [Understand the Structure](./platform-components/platform-components.md) - overview of _Reflex_ applications components
 
 * [Demos](./demo/demo.md) - try _Reflex_ by downloading and running simple demo applications and looking at their sources
+
+* [Reproducible Configuration Assembly](./configuration/configuration-assembly.md) - design for validating and closing packaged application configuration

--- a/reflex-platform-test/src/hiconic/rx/platform/conf/RxPropertyResolverTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/conf/RxPropertyResolverTest.java
@@ -78,6 +78,24 @@ public class RxPropertyResolverTest {
 		assertThat(resolver.resolve("key")).isEqualTo("sysValue");
 	}
 
+	@Test
+	public void testManagedModeDoesNotFallBackToHostProperties() {
+		systemProps.put("SYSTEM_VALUE", "hidden");
+		envVars.put("ENV_VALUE", "hidden");
+		resolver.setManagedPropertiesOnly(true);
+
+		assertThat(resolver.resolve("SYSTEM_VALUE")).isNull();
+		assertThat(resolver.resolve("ENV_VALUE")).isNull();
+	}
+
+	@Test
+	public void testManagedModeResolvesMaterializedImportsLikeNormalProperties() {
+		rawProperties.put("IMPORTED_VALUE", "managed");
+		resolver.setManagedPropertiesOnly(true);
+
+		assertThat(resolver.resolve("IMPORTED_VALUE")).isEqualTo("managed");
+	}
+
 	// ENV_PREFIX
 
 	@Test

--- a/reflex-platform-test/src/hiconic/rx/platform/configuration/ConfigurationPropertyImportsTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/configuration/ConfigurationPropertyImportsTest.java
@@ -1,0 +1,98 @@
+package hiconic.rx.platform.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.braintribe.gm.config.yaml.index.ClasspathEntry;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.ve.api.VirtualEnvironment;
+
+import hiconic.rx.platform.conf.ConfigurationPropertyImports;
+
+public class ConfigurationPropertyImportsTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private final Map<String, String> environment = new java.util.LinkedHashMap<>();
+	private final Map<String, String> systemProperties = new java.util.LinkedHashMap<>();
+
+	@Test
+	public void bindsOnlyDeclaredImportsAndPrefersSystemProperties() throws Exception {
+		ConfigurationImportDeclarations declarations = declarations("""
+				imports:
+				  - name: REQUIRED
+				    required: true
+				  - name: OPTIONAL
+				    required: false
+				""");
+		environment.put("REQUIRED", "environment");
+		systemProperties.put("REQUIRED", "system");
+		environment.put("UNDECLARED", "invisible");
+
+		Maybe<Map<String, String>> result = ConfigurationPropertyImports.bind(Map.of("LOCAL", "local"), declarations, virtualEnvironment());
+
+		assertThat(result.isSatisfied()).isTrue();
+		assertThat(result.get()).containsEntry("LOCAL", "local").containsEntry("REQUIRED", "system");
+		assertThat(result.get()).doesNotContainKeys("OPTIONAL", "UNDECLARED");
+	}
+
+	@Test
+	public void locallyManagedValueSatisfiesRequiredImportWithoutHostLookup() throws Exception {
+		ConfigurationImportDeclarations declarations = declarations("""
+				imports:
+				  - name: REQUIRED
+				    required: true
+				""");
+
+		Maybe<Map<String, String>> result = ConfigurationPropertyImports.bind(Map.of("REQUIRED", "local"), declarations,
+				virtualEnvironment());
+
+		assertThat(result.isSatisfied()).isTrue();
+		assertThat(result.get()).containsEntry("REQUIRED", "local");
+	}
+
+	@Test
+	public void rejectsMissingRequiredImport() throws Exception {
+		ConfigurationImportDeclarations declarations = declarations("""
+				imports:
+				  - name: REQUIRED
+				    required: true
+				""");
+
+		Maybe<Map<String, String>> result = ConfigurationPropertyImports.bind(Map.of(), declarations, virtualEnvironment());
+
+		assertThat(result.isUnsatisfied()).isTrue();
+		assertThat(result.whyUnsatisfied().stringify()).contains("REQUIRED");
+	}
+
+	private ConfigurationImportDeclarations declarations(String yaml) throws Exception {
+		File file = temporaryFolder.newFile("configuration-imports.yaml");
+		Files.writeString(file.toPath(), yaml, StandardCharsets.UTF_8);
+		ClasspathEntry entry = new ClasspathEntry(ConfigurationImportDeclarations.RESOURCE_PATH, file.toURI().toURL(), "test");
+		return ConfigurationImportDeclarations.read(List.of(new ConfigurationImportDeclarations.DeclarationSource("test", entry))).get();
+	}
+
+	private VirtualEnvironment virtualEnvironment() {
+		return new VirtualEnvironment() {
+			@Override
+			public String getEnv(String name) {
+				return environment.get(name);
+			}
+
+			@Override
+			public String getProperty(String name) {
+				return systemProperties.get(name);
+			}
+		};
+	}
+}

--- a/reflex-platform/pom.xml
+++ b/reflex-platform/pom.xml
@@ -61,6 +61,12 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>com.braintribe.gm</groupId>
+            <artifactId>configuration-assembly-model</artifactId>
+            <version>${V.com.braintribe.gm}</version>
+            <?tag asset?>
+        </dependency>
+        <dependency>
+            <groupId>com.braintribe.gm</groupId>
             <artifactId>json-marshaller</artifactId>
             <version>${V.com.braintribe.gm}</version>
         </dependency>

--- a/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
+++ b/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
@@ -41,6 +41,7 @@ import com.braintribe.gm.config.yaml.index.ClasspathIndex;
 import com.braintribe.gm.model.reason.ReasonException;
 import com.braintribe.gm.model.reason.UnsatisfiedMaybeTunneling;
 import com.braintribe.logging.level.LogLevelSetup;
+import com.braintribe.ve.impl.StandardEnvironment;
 import com.braintribe.wire.api.Wire;
 import com.braintribe.wire.api.context.WireContext;
 import com.braintribe.wire.impl.properties.PropertyLookups;
@@ -49,9 +50,11 @@ import ch.qos.logback.classic.LoggerContext;
 import hiconic.rx.module.api.service.ServiceDomain;
 import hiconic.rx.module.api.wire.RxPlatformContract;
 import hiconic.rx.platform.conf.ApplicationProperties;
+import hiconic.rx.platform.conf.ConfigurationPropertyImports;
 import hiconic.rx.platform.conf.RxConfigurationConstants;
 import hiconic.rx.platform.conf.RxPropertyResolver;
 import hiconic.rx.platform.conf.SystemProperties;
+import hiconic.rx.platform.configuration.ConfigurationImportDeclarations;
 import hiconic.rx.platform.logging.LayeredLogbackConfiguration;
 import hiconic.rx.platform.logging.LayeredLogLevelPersistence;
 import hiconic.rx.platform.logging.LogbackLogLevelFramework;
@@ -266,6 +269,15 @@ public class RxPlatform implements AutoCloseable {
 		File confDir = new File(systemProperties.appDir(), "conf");
 		Map<String, String> rawProperties = UnsatisfiedMaybeTunneling.getOrTunnel(
 				RxPropertiesLoader.loadLayered(confDir, RxConfigurationConstants.CLASSPATH_CONF_PATH, "properties", new YamlMarshaller(), classpathIndex));
+
+		ConfigurationImportDeclarations imports = UnsatisfiedMaybeTunneling.getOrTunnel(
+				ConfigurationImportDeclarations.read(classpathIndex));
+		if (imports.declaredConfiguration()) {
+			rawProperties = UnsatisfiedMaybeTunneling.getOrTunnel(
+					ConfigurationPropertyImports.bind(rawProperties, imports, StandardEnvironment.INSTANCE));
+			resolver.setManagedPropertiesOnly(true);
+		}
+
 		resolver.setRawProperties(rawProperties);
 		return resolver;
 	}

--- a/reflex-platform/src/hiconic/rx/platform/conf/ConfigurationPropertyImports.java
+++ b/reflex-platform/src/hiconic/rx/platform/conf/ConfigurationPropertyImports.java
@@ -1,0 +1,66 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.conf;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.braintribe.gm.config.assembly.model.ConfigurationImport;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reasons;
+import com.braintribe.gm.model.reason.config.ConfigurationError;
+import com.braintribe.ve.api.VirtualEnvironment;
+
+import hiconic.rx.platform.configuration.ConfigurationImportDeclarations;
+
+/**
+ * Materializes explicitly declared deployment imports into the managed RX property graph.
+ * <p>
+ * Environment and system properties are deliberately consulted only here. Downstream configuration resolution therefore has one complete,
+ * inspectable source map rather than an implicit fallback into the host process.
+ */
+public final class ConfigurationPropertyImports {
+
+	private ConfigurationPropertyImports() {
+	}
+
+	public static Maybe<Map<String, String>> bind(Map<String, String> rawProperties,
+			ConfigurationImportDeclarations declarations, VirtualEnvironment environment) {
+		Map<String, String> result = new LinkedHashMap<>(rawProperties);
+		var errors = Reasons.aggregatorForceWrap(() -> ConfigurationError.create("Missing required configuration imports"));
+
+		for (ConfigurationImport declaration : declarations.imports()) {
+			String name = declaration.getName();
+			if (result.containsKey(name))
+				continue;
+
+			String value = environment.getProperty(name);
+			if (value == null)
+				value = environment.getEnv(name);
+
+			if (value != null) {
+				result.put(name, value);
+				continue;
+			}
+
+			if (declaration.getRequired())
+				errors.accept(ConfigurationError.create("Required configuration import [" + name + "] was not supplied"));
+		}
+
+		if (errors.hasReason())
+			return errors.get().asMaybe();
+
+		return Maybe.complete(Map.copyOf(result));
+	}
+}

--- a/reflex-platform/src/hiconic/rx/platform/conf/RxPropertyExpression.java
+++ b/reflex-platform/src/hiconic/rx/platform/conf/RxPropertyExpression.java
@@ -1,0 +1,58 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.conf;
+
+import java.util.Optional;
+
+/**
+ * Shared syntax recognition for RX property-expression functions.
+ * <p>
+ * Evaluation deliberately remains with the respective runtime or symbolic resolver.
+ */
+public final class RxPropertyExpression {
+
+	private RxPropertyExpression() {
+	}
+
+	public static Optional<FunctionCall> functionCall(String placeholder) {
+		if (!placeholder.contains("(") || !placeholder.endsWith(")"))
+			return Optional.empty();
+
+		int opening = placeholder.indexOf('(');
+		int closing = placeholder.lastIndexOf(')');
+		if (opening <= 0 || closing <= opening)
+			return Optional.empty();
+
+		return Optional.of(new FunctionCall(
+				placeholder.substring(0, opening),
+				placeholder.substring(opening + 1, closing)));
+	}
+
+	public record FunctionCall(String name, String rawParameter) {
+
+		public Optional<String> nestedProperty() {
+			if (rawParameter.startsWith("${") && rawParameter.endsWith("}"))
+				return Optional.of(rawParameter.substring(2, rawParameter.length() - 1));
+			return Optional.empty();
+		}
+
+		public String unquotedParameter() {
+			if (rawParameter.length() >= 2
+					&& (rawParameter.startsWith("'") && rawParameter.endsWith("'")
+							|| rawParameter.startsWith("\"") && rawParameter.endsWith("\"")))
+				return rawParameter.substring(1, rawParameter.length() - 1);
+			return rawParameter;
+		}
+	}
+}

--- a/reflex-platform/src/hiconic/rx/platform/conf/RxPropertyResolver.java
+++ b/reflex-platform/src/hiconic/rx/platform/conf/RxPropertyResolver.java
@@ -42,6 +42,7 @@ public class RxPropertyResolver implements PropertyResolver {
 	private Map<String, String> rawProperties = Collections.emptyMap();
 	private final Map<String, Maybe<String>> resolvedProperties = new ConcurrentHashMap<>();
 	private VirtualEnvironment virtualEnvironment = StandardEnvironment.INSTANCE;
+	private boolean managedPropertiesOnly;
 
 	@Configurable
 	public void setRawProperties(Map<String, String> rawProperties) {
@@ -51,6 +52,14 @@ public class RxPropertyResolver implements PropertyResolver {
 	@Configurable
 	public void setVirtualEnvironment(VirtualEnvironment virtualEnvironment) {
 		this.virtualEnvironment = virtualEnvironment;
+	}
+
+	/**
+	 * Disables all implicit system-property and environment fallbacks. Imported values must already be materialized in {@link #rawProperties}.
+	 */
+	@Configurable
+	public void setManagedPropertiesOnly(boolean managedPropertiesOnly) {
+		this.managedPropertiesOnly = managedPropertiesOnly;
 	}
 
 	@Override
@@ -111,15 +120,18 @@ public class RxPropertyResolver implements PropertyResolver {
 	}
 
 	private String findRawValue(String name) {
+		String value = rawProperties.get(name);
+		if (value != null)
+			return value;
+
+		if (managedPropertiesOnly)
+			return null;
+
 		if (name.startsWith(PropertyResolutions.ENV_PREFIX)) {
 			String envName = name.substring(PropertyResolutions.ENV_PREFIX.length());
 
 			return virtualEnvironment.getEnv(envName);
 		}
-
-		String value = rawProperties.get(name);
-		if (value != null)
-			return value;
 
 		value = virtualEnvironment.getProperty(name);
 		if (value != null)
@@ -147,57 +159,40 @@ public class RxPropertyResolver implements PropertyResolver {
 		}
 
 		private Maybe<String> resolvePlaceholderReasoned(String placeholder) {
-			if (placeholder.contains("(") && placeholder.endsWith(")")) {
-				int idx1 = placeholder.indexOf("(");
-				int idx2 = placeholder.lastIndexOf(")");
-				if (idx1 > 0 && idx2 > idx1) {
-					String method = placeholder.substring(0, idx1);
-					String rawParam = placeholder.substring(idx1 + 1, idx2);
-
-					String param;
-					if (rawParam.startsWith("${") && rawParam.endsWith("}")) {
-						// To support param being another variable "${decrypt(${SECRET_PARAM})} 
-						String nestedProperty = rawParam.substring(2, rawParam.length() - 1);
-						var paramMaybe = resolveReasoned(nestedProperty);
-						if (paramMaybe.isUnsatisfied())
-							return Reasons.build(UnresolvedProperty.T) //
-									.text("Could not resolve parameter [" + rawParam + "] for method [" + method + "]") //
-									.cause(paramMaybe.whyUnsatisfied()) //
-									.toMaybe();
-						
-						param = paramMaybe.get();
-
-					} else {
-						param = rawParam;
-					}
-
-					switch (method) {
-						case "decrypt": {
-							if ((param.startsWith("'") && param.endsWith("'")) || (param.startsWith("\"") && param.endsWith("\"")))
-								param = param.substring(1, param.length() - 1);
-
-							Maybe<String> maybeSecret = resolveReasoned(RxPlatform.PROPERTY_DECRYPT_SECRET);
-							if (maybeSecret.isUnsatisfied())
-								return Reasons.build(ConfigurationError.T).text("Could not resolve decryption secret") //
-										.cause(maybeSecret.whyUnsatisfied()).toMaybe();
-
-							try {
-								String secret = maybeSecret.get();
-								String decryptedValue = Cryptor.decrypt(secret, null, null, null, param);
-								return Maybe.complete(decryptedValue);
-
-							} catch (Exception e) {
-								return Reasons.build(ConfigurationError.T).text("Wrong decryption secret").toMaybe();
-							}
-						}
-
-						default:
-							return Reasons.build(UnsupportedOperation.T).text("Unsupported operation: " + method).toMaybe();
-					}
-				}
-			}
+			var functionCall = RxPropertyExpression.functionCall(placeholder);
+			if (functionCall.isPresent())
+				return resolveFunction(functionCall.get());
 
 			return resolveReasoned(placeholder);
+		}
+
+		private Maybe<String> resolveFunction(RxPropertyExpression.FunctionCall function) {
+			Maybe<String> paramMaybe = function.nestedProperty()
+					.map(RxPropertyResolver.this::resolveReasoned)
+					.orElseGet(() -> Maybe.complete(function.unquotedParameter()));
+			if (paramMaybe.isUnsatisfied())
+				return Reasons.build(UnresolvedProperty.T)
+						.text("Could not resolve parameter [" + function.rawParameter() + "] for method [" + function.name() + "]")
+						.cause(paramMaybe.whyUnsatisfied())
+						.toMaybe();
+
+			return switch (function.name()) {
+				case "decrypt" -> decrypt(paramMaybe.get());
+				default -> Reasons.build(UnsupportedOperation.T).text("Unsupported operation: " + function.name()).toMaybe();
+			};
+		}
+
+		private Maybe<String> decrypt(String encryptedValue) {
+			Maybe<String> maybeSecret = resolveReasoned(RxPlatform.PROPERTY_DECRYPT_SECRET);
+			if (maybeSecret.isUnsatisfied())
+				return Reasons.build(ConfigurationError.T).text("Could not resolve decryption secret")
+						.cause(maybeSecret.whyUnsatisfied()).toMaybe();
+
+			try {
+				return Maybe.complete(Cryptor.decrypt(maybeSecret.get(), null, null, null, encryptedValue));
+			} catch (Exception e) {
+				return Reasons.build(ConfigurationError.T).text("Wrong decryption secret").toMaybe();
+			}
 		}
 	}
 }

--- a/reflex-platform/src/hiconic/rx/platform/configuration/ConfigurationImportDeclarations.java
+++ b/reflex-platform/src/hiconic/rx/platform/configuration/ConfigurationImportDeclarations.java
@@ -1,0 +1,171 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.configuration;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
+import com.braintribe.gm.config.assembly.model.ConfigurationImport;
+import com.braintribe.gm.config.assembly.model.ConfigurationImports;
+import com.braintribe.gm.config.yaml.YamlConfigurations;
+import com.braintribe.gm.config.yaml.index.ClasspathEntry;
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reasons;
+import com.braintribe.gm.model.reason.config.ConfigurationError;
+
+/**
+ * Reads, validates and merges the deployment-property declarations carried by configuration artifacts.
+ * <p>
+ * This class intentionally knows neither Ant nor artifact resolution. Its complete input is the same indexed resource view used by the application.
+ */
+public final class ConfigurationImportDeclarations {
+
+	public static final String RESOURCE_PATH = "META-INF/configuration-imports.yaml";
+	public static final Set<String> PLATFORM_VARIABLES = Set.of("reflex.app.dir");
+
+	private final Map<String, ConfigurationImport> importsByName;
+	private final boolean declaredConfiguration;
+
+	private ConfigurationImportDeclarations(Map<String, ConfigurationImport> importsByName, boolean declaredConfiguration) {
+		this.importsByName = Map.copyOf(importsByName);
+		this.declaredConfiguration = declaredConfiguration;
+	}
+
+	public static Maybe<ConfigurationImportDeclarations> read(ClasspathIndex classpathIndex) {
+		Objects.requireNonNull(classpathIndex, "classpathIndex");
+
+		List<DeclarationSource> sources = classpathIndex.forPrefix(RESOURCE_PATH).stream()
+				.filter(entry -> entry.path.equals(RESOURCE_PATH))
+				.map(ConfigurationImportDeclarations::source)
+				.toList();
+
+		return read(sources);
+	}
+
+	static Maybe<ConfigurationImportDeclarations> read(List<DeclarationSource> sources) {
+		var errors = Reasons.aggregatorForceWrap(() -> ConfigurationError.create("Invalid configuration import declarations"));
+		Map<String, DeclaredImport> merged = new LinkedHashMap<>();
+
+		for (DeclarationSource source : sources) {
+			Maybe<ConfigurationImports> declarationsMaybe = YamlConfigurations.read(ConfigurationImports.T).from(source.entry().url);
+			if (declarationsMaybe.isUnsatisfied()) {
+				errors.accept(Reasons.build(ConfigurationError.T)
+						.text("Could not read configuration imports from " + source.origin())
+						.cause(declarationsMaybe.whyUnsatisfied())
+						.toReason());
+				continue;
+			}
+
+			ConfigurationImports declarations = declarationsMaybe.get();
+			for (ConfigurationImport declaration : declarations.getImports())
+				merge(source.origin(), declaration, merged, errors);
+		}
+
+		Map<String, ConfigurationImport> result = new LinkedHashMap<>();
+		merged.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> result.put(entry.getKey(), entry.getValue().declaration()));
+
+		ConfigurationImportDeclarations declarations = new ConfigurationImportDeclarations(result, !sources.isEmpty());
+		if (errors.hasReason())
+			return Maybe.incomplete(declarations, errors.get());
+
+		return Maybe.complete(declarations);
+	}
+
+	public List<ConfigurationImport> imports() {
+		return importsByName.values().stream().sorted(Comparator.comparing(ConfigurationImport::getName)).toList();
+	}
+
+	public Set<String> names() {
+		return importsByName.keySet();
+	}
+
+	/**
+	 * Returns whether at least one import descriptor was present.
+	 * <p>
+	 * This distinction lets applications without descriptors retain the legacy property lookup during migration, while even an intentionally empty
+	 * descriptor opts an application into the managed-property regime.
+	 */
+	public boolean declaredConfiguration() {
+		return declaredConfiguration;
+	}
+
+	/**
+	 * Builds the import-related part of an assembly report. An unresolved variable is legal exactly when an artifact declared it as an import.
+	 */
+	public ConfigurationAssemblyReport report(Collection<String> unresolvedVariables) {
+		Set<String> unresolved = new LinkedHashSet<>(unresolvedVariables);
+		List<String> sortedUnresolved = unresolved.stream().sorted().toList();
+		List<String> platformVariables = unresolved.stream().filter(PLATFORM_VARIABLES::contains).sorted().toList();
+		List<String> undeclared = unresolved.stream()
+				.filter(name -> !PLATFORM_VARIABLES.contains(name))
+				.filter(name -> !importsByName.containsKey(name))
+				.sorted()
+				.toList();
+
+		ConfigurationAssemblyReport report = ConfigurationAssemblyReport.T.create();
+		report.setImports(new ArrayList<>(imports()));
+		report.setUnresolvedVariables(sortedUnresolved);
+		report.setUndeclaredVariables(undeclared);
+		report.setPlatformVariables(platformVariables);
+		return report;
+	}
+
+	private static DeclarationSource source(ClasspathEntry entry) {
+		String origin = entry.origin.isBlank() ? entry.url.toString() : entry.origin;
+		return new DeclarationSource(origin, entry);
+	}
+
+	private static void merge(String origin, ConfigurationImport declaration, Map<String, DeclaredImport> merged,
+			com.braintribe.gm.model.reason.ReasonAggregator<ConfigurationError> errors) {
+		String name = declaration.getName();
+		if (name == null || name.isBlank()) {
+			errors.accept(ConfigurationError.create("Configuration import without a name in " + origin));
+			return;
+		}
+
+		DeclaredImport previous = merged.get(name);
+		if (previous == null) {
+			merged.put(name, new DeclaredImport(origin, declaration));
+			return;
+		}
+
+		if (!equivalent(previous.declaration(), declaration)) {
+			errors.accept(ConfigurationError.create("Incompatible declarations for configuration import [" + name + "] in ["
+					+ previous.origin() + "] and [" + origin + "]"));
+		}
+	}
+
+	private static boolean equivalent(ConfigurationImport left, ConfigurationImport right) {
+		return left.getRequired() == right.getRequired()
+				&& left.getConfidential() == right.getConfidential()
+				&& Objects.equals(left.getDescription(), right.getDescription());
+	}
+
+	record DeclarationSource(String origin, ClasspathEntry entry) {
+	}
+
+	private record DeclaredImport(String origin, ConfigurationImport declaration) {
+	}
+}


### PR DESCRIPTION
Introduces build-time configuration assembly and validation on the real application classpath, explicit import declarations, canonical output, and managed runtime import binding. Legacy property resolution remains unchanged unless import management is enabled.\n\nEvidence: configuration-assembly-processing-test and reflex-platform-test pass; real Proventem local assembly produced canonical configuration with only declared deployment imports unresolved.