### PR TITLE
Consume effective packaged configuration

### DIFF
--- a/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMainTest.java
+++ b/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMainTest.java
@@ -32,14 +32,19 @@ public class ConfigurationAssemblyMainTest {
 	@Test
 	public void assemblesAnEmptyApplicationUsingOnlyFilesystemInputs() throws Exception {
 		Path application = temporaryFolder.newFolder("application").toPath();
-		Files.createDirectories(application.resolve("classpath-resources"));
+		Path packagedResources = application.resolve("packaged-resources");
+		Files.createDirectories(packagedResources);
+		Files.writeString(packagedResources.resolve("index.properties"), """
+				formatVersion=1
+				artifact.count=0
+				""");
 		Files.createDirectories(application.resolve("conf"));
 
 		int status = ConfigurationAssemblyMain.run(new String[] { "--application-dir", application.toString() });
 
 		assertThat(status).isZero();
-		assertThat(application.resolve("packaged-conf/effective")).isDirectory();
-		assertThat(application.resolve("packaged-conf/assembly-report.yaml")).isRegularFile();
+		assertThat(application.resolve("effective-conf/compiled")).isDirectory();
+		assertThat(application.resolve("configuration-compilation.yaml")).isRegularFile();
 	}
 
 	@Test

--- a/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationImportDeclarationsTest.java
+++ b/configuration-assembly-processing-test/src/hiconic/rx/platform/configuration/ConfigurationImportDeclarationsTest.java
@@ -183,22 +183,21 @@ public class ConfigurationImportDeclarationsTest {
 		assertThat(assembly.report().getAssembledConfigurations())
 				.containsExactly(SampleConfiguration.T.getTypeSignature());
 
-		Path output = temporaryFolder.newFolder("packaged-conf").toPath();
-		Path rawProjection = output.resolve("sample-artifact/sample-configuration.yaml");
-		Files.createDirectories(rawProjection.getParent());
-		Files.writeString(rawProjection, "raw: retained\n");
-		Path staleEffective = output.resolve("effective/stale-configuration.yaml");
+		Path output = temporaryFolder.newFolder("effective-conf").toPath();
+		Path staleEffective = output.resolve("compiled/stale-configuration.yaml");
 		Files.createDirectories(staleEffective.getParent());
 		Files.writeString(staleEffective, "stale: true\n");
+		Path protocol = output.getParent().resolve("configuration-compilation.yaml");
 
-		var writeMaybe = ConfigurationAssemblyWriter.write(assembly, output);
+		var writeMaybe = ConfigurationAssemblyWriter.write(assembly, new ClasspathIndex(root), output, protocol);
 		assertThat(writeMaybe.isSatisfied()).isTrue();
-		String effectiveYaml = Files.readString(output.resolve("effective/sample-configuration.yaml"));
+		String effectiveYaml = Files.readString(output.resolve("compiled/sample-configuration.yaml"));
 		assertThat(effectiveYaml).contains("label: \"filesystem\"");
 		assertThat(effectiveYaml).contains("${DB_DEFAULT_URL}");
 		assertThat(staleEffective).doesNotExist();
-		assertThat(rawProjection).exists();
-		assertThat(output.resolve(ConfigurationAssemblyWriter.REPORT_FILE)).exists();
+		assertThat(output.resolve("base/unknown-configuration.yaml")).hasContent("value: retained");
+		assertThat(output.resolve("compiled/properties.yaml")).content().contains("DB_DEFAULT_URL");
+		assertThat(protocol).exists();
 	}
 
 	@Test

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssembly.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssembly.java
@@ -17,6 +17,7 @@ package hiconic.rx.platform.configuration;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
 import com.braintribe.model.generic.GenericEntity;
@@ -31,12 +32,14 @@ public record ConfigurationAssembly(
 		Map<ConfigurationKey, GenericEntity> configurations,
 		Map<String, String> rawProperties,
 		Map<String, String> resolvedProperties,
+		Set<String> consumedResources,
 		ConfigurationAssemblyReport report) {
 
 	public ConfigurationAssembly {
 		configurations = Map.copyOf(configurations);
 		rawProperties = Map.copyOf(rawProperties);
 		resolvedProperties = Map.copyOf(resolvedProperties);
+		consumedResources = Set.copyOf(consumedResources);
 	}
 
 	public List<ConfigurationKey> keys() {

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMain.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyMain.java
@@ -41,10 +41,15 @@ public final class ConfigurationAssemblyMain {
 		try {
 			Map<String, String> options = parse(args);
 			Path applicationDirectory = requiredPath(options, "--application-dir");
-			Path resourcesDirectory = optionPath(options, "--classpath-resources",
-					applicationDirectory.resolve("classpath-resources"));
-			Path outputDirectory = optionPath(options, "--output-dir", applicationDirectory.resolve("packaged-conf"));
-			Path confDirectory = optionPath(options, "--conf-dir", applicationDirectory.resolve("conf"));
+			Path defaultResources = Files.isDirectory(applicationDirectory.resolve("packaged-resources"))
+					? applicationDirectory.resolve("packaged-resources")
+					: applicationDirectory.resolve("classpath-resources");
+			Path resourcesDirectory = aliasedOptionPath(options, "--packaged-resources", "--classpath-resources", defaultResources);
+			Path outputDirectory = optionPath(options, "--output-dir", applicationDirectory.resolve("effective-conf"));
+			Path protocolFile = optionPath(options, "--protocol-file",
+					applicationDirectory.resolve(ConfigurationAssemblyWriter.PROTOCOL_FILE));
+			// Deployment conf remains a later override layer and is deliberately not folded into the packaged baseline.
+			Path confDirectory = optionPath(options, "--conf-dir", applicationDirectory.resolve(".configuration-assembly-empty-conf"));
 			if (!options.isEmpty())
 				throw new IllegalArgumentException("Unknown configuration assembly option(s): " + String.join(", ", options.keySet()));
 
@@ -59,21 +64,21 @@ public final class ConfigurationAssemblyMain {
 				return 1;
 			}
 
-			Maybe<Void> writeMaybe = ConfigurationAssemblyWriter.write(assemblyMaybe.get(), outputDirectory);
+			Maybe<Void> writeMaybe = ConfigurationAssemblyWriter.write(assemblyMaybe.get(), index, outputDirectory, protocolFile);
 			if (writeMaybe.isUnsatisfied()) {
 				System.err.println(writeMaybe.whyUnsatisfied().stringify());
 				return 1;
 			}
 
 			ConfigurationAssembly assembly = assemblyMaybe.get();
-			System.out.println("Assembled " + assembly.configurations().size() + " modeled configuration(s) into " + outputDirectory);
+			System.out.println("Compiled " + assembly.configurations().size() + " modeled configuration(s) into " + outputDirectory);
 			if (!assembly.report().getResidualResources().isEmpty())
 				System.out.println("Retained " + assembly.report().getResidualResources().size() + " residual configuration resource(s)");
 			return 0;
 		} catch (IllegalArgumentException e) {
 			System.err.println(e.getMessage());
 			System.err.println("Usage: ConfigurationAssemblyMain --application-dir <path> "
-					+ "[--classpath-resources <path>] [--conf-dir <path>] [--output-dir <path>]");
+					+ "[--packaged-resources <path>] [--conf-dir <path>] [--output-dir <path>] [--protocol-file <path>]");
 			return 2;
 		}
 	}
@@ -105,5 +110,16 @@ public final class ConfigurationAssemblyMain {
 		if (value == null || value.isBlank())
 			return defaultValue.toAbsolutePath().normalize();
 		return Path.of(value).toAbsolutePath().normalize();
+	}
+
+	private static Path aliasedOptionPath(Map<String, String> options, String name, String legacyName, Path defaultValue) {
+		String value = options.remove(name);
+		String legacyValue = options.remove(legacyName);
+		if (value != null && legacyValue != null)
+			throw new IllegalArgumentException("Options " + name + " and " + legacyName + " are mutually exclusive");
+		String selected = value != null ? value : legacyValue;
+		if (selected == null || selected.isBlank())
+			return defaultValue.toAbsolutePath().normalize();
+		return Path.of(selected).toAbsolutePath().normalize();
 	}
 }

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyWriter.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ConfigurationAssemblyWriter.java
@@ -16,6 +16,7 @@
 package hiconic.rx.platform.configuration;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
@@ -23,7 +24,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import com.braintribe.codec.marshaller.api.GmSerializationOptions;
 import com.braintribe.codec.marshaller.api.OutputPrettiness;
@@ -33,44 +39,111 @@ import com.braintribe.codec.marshaller.api.TypeExplicitnessOption;
 import com.braintribe.codec.marshaller.yaml.YamlMarshaller;
 import com.braintribe.gm.config.assembly.model.ConfigurationAssemblyReport;
 import com.braintribe.gm.config.yaml.YamlConfigurations;
+import com.braintribe.gm.config.yaml.index.ClasspathEntry;
+import com.braintribe.gm.config.yaml.index.ClasspathIndex;
 import com.braintribe.gm.model.reason.Maybe;
 import com.braintribe.gm.model.reason.Reasons;
 import com.braintribe.gm.model.reason.config.ConfigurationError;
 import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.EssentialTypes;
+import com.braintribe.model.generic.reflection.MapType;
+import com.braintribe.model.generic.GMF;
 
 /**
  * Writes the canonical modeled closure and validates every written entity by parsing and serializing it again.
  */
 public final class ConfigurationAssemblyWriter {
 
-	public static final String EFFECTIVE_DIRECTORY = "effective";
-	public static final String REPORT_FILE = "assembly-report.yaml";
+	public static final String COMPILED_SLOT = "compiled";
+	public static final String PROTOCOL_FILE = "configuration-compilation.yaml";
+	private static final String CLASSPATH_CONF_PREFIX = "HICONIC-CONF/";
 
 	private ConfigurationAssemblyWriter() {
 	}
 
-	public static Maybe<Void> write(ConfigurationAssembly assembly, Path packagedConfDirectory) {
-		Path effectiveDirectory = packagedConfDirectory.resolve(EFFECTIVE_DIRECTORY);
+	public static Maybe<Void> write(ConfigurationAssembly assembly, ClasspathIndex sourceIndex, Path effectiveDirectory, Path protocolFile) {
 		try {
 			recreateDirectory(effectiveDirectory);
+			Path compiledDirectory = effectiveDirectory.resolve(COMPILED_SLOT);
+			Files.createDirectories(compiledDirectory);
 
 			for (Map.Entry<ConfigurationKey, GenericEntity> entry : assembly.configurations().entrySet()) {
 				String yaml = serialize(entry.getValue(), entry.getKey().type());
 				Maybe<Void> roundtripMaybe = verifyRoundtrip(entry.getKey(), yaml);
 				if (roundtripMaybe.isUnsatisfied())
 					return roundtripMaybe;
-				Files.writeString(effectiveDirectory.resolve(entry.getKey().fileName()), yaml, StandardCharsets.UTF_8);
+				Files.writeString(compiledDirectory.resolve(entry.getKey().fileName()), yaml, StandardCharsets.UTF_8);
 			}
 
+			Map<String, String> effectiveProperties = effectiveProperties(assembly);
+			if (!effectiveProperties.isEmpty())
+				Files.writeString(compiledDirectory.resolve("properties.yaml"), serializeProperties(effectiveProperties), StandardCharsets.UTF_8);
+
+			List<String> residualResources = copyResidualResources(assembly, sourceIndex, effectiveDirectory);
+			assembly.report().setResidualResources(residualResources);
 			String reportYaml = serialize(assembly.report(), ConfigurationAssemblyReport.T);
-			Files.writeString(packagedConfDirectory.resolve(REPORT_FILE), reportYaml, StandardCharsets.UTF_8);
+			Files.writeString(protocolFile, reportYaml, StandardCharsets.UTF_8);
 			return Maybe.complete(null);
 		} catch (IOException | UncheckedIOException e) {
 			return Reasons.build(ConfigurationError.T)
-					.text("Could not write assembled configuration to " + packagedConfDirectory + ": " + e)
+					.text("Could not write assembled configuration to " + effectiveDirectory + ": " + e)
 					.toMaybe();
 		}
+	}
+
+	private static Map<String, String> effectiveProperties(ConfigurationAssembly assembly) {
+		Map<String, String> result = new TreeMap<>();
+		assembly.rawProperties().forEach((name, rawValue) ->
+				result.put(name, assembly.resolvedProperties().getOrDefault(name, rawValue)));
+		return result;
+	}
+
+	private static List<String> copyResidualResources(ConfigurationAssembly assembly, ClasspathIndex sourceIndex, Path effectiveDirectory)
+			throws IOException {
+		Map<String, String> slotsByOrigin = new LinkedHashMap<>();
+		Set<String> usedSlots = new HashSet<>();
+		Map<Path, ClasspathEntry> targets = new LinkedHashMap<>();
+		List<String> residual = new java.util.ArrayList<>();
+
+		for (ClasspathEntry entry : sourceIndex.forPrefix(CLASSPATH_CONF_PREFIX)) {
+			String relative = entry.path.substring(CLASSPATH_CONF_PREFIX.length());
+			if (relative.isEmpty() || assembly.consumedResources().contains(relative))
+				continue;
+
+			String origin = entry.origin.isBlank() ? "classpath" : entry.origin;
+			String slot = slotsByOrigin.computeIfAbsent(origin, key -> uniqueSlot(key, usedSlots));
+			Path target = effectiveDirectory.resolve(slot).resolve(relative).normalize();
+			if (!target.startsWith(effectiveDirectory.resolve(slot).normalize()))
+				throw new IOException("Residual configuration resource escapes its slot: " + entry.path);
+
+			ClasspathEntry previous = targets.putIfAbsent(target, entry);
+			if (previous != null)
+				throw new IOException("Residual configuration collision at " + target + " between "
+						+ previous.origin + " and " + entry.origin);
+
+			Files.createDirectories(target.getParent());
+			try (InputStream in = entry.url.openStream()) {
+				Files.copy(in, target);
+			}
+			residual.add(slot + "/" + relative);
+		}
+
+		return residual.stream().sorted().toList();
+	}
+
+	private static String uniqueSlot(String origin, Set<String> usedSlots) {
+		String base = sanitizeSlot(origin);
+		String candidate = base;
+		int suffix = 2;
+		while (!usedSlots.add(candidate))
+			candidate = base + "-" + suffix++;
+		return candidate;
+	}
+
+	private static String sanitizeSlot(String value) {
+		String result = value.replaceAll("[^A-Za-z0-9._-]", "_");
+		return result.isEmpty() ? "artifact" : result;
 	}
 
 	private static void recreateDirectory(Path directory) throws IOException {
@@ -111,6 +184,18 @@ public final class ConfigurationAssemblyWriter {
 
 		StringWriter writer = new StringWriter();
 		new YamlMarshaller().marshall(writer, entity, options);
+		return writer.toString();
+	}
+
+	private static String serializeProperties(Map<String, String> properties) {
+		MapType type = GMF.getTypeReflection().getMapType(EssentialTypes.TYPE_STRING, EssentialTypes.TYPE_STRING);
+		GmSerializationOptions options = GmSerializationOptions.deriveDefaults()
+				.inferredRootType(type)
+				.outputPrettiness(OutputPrettiness.high)
+				.set(PlaceholderSupport.class, true)
+				.build();
+		StringWriter writer = new StringWriter();
+		new YamlMarshaller().marshall(writer, properties, options);
 		return writer.toString();
 	}
 }

--- a/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ModeledConfigurationAssembler.java
+++ b/configuration-assembly-processing/src/hiconic/rx/platform/configuration/ModeledConfigurationAssembler.java
@@ -132,7 +132,7 @@ public final class ModeledConfigurationAssembler {
 					+ String.join(", ", report.getUndeclaredVariables())));
 
 		ConfigurationAssembly assembly = new ConfigurationAssembly(configurations, symbolicProperties.rawProperties(),
-				symbolicProperties.resolvedProperties(), report);
+				symbolicProperties.resolvedProperties(), discovery.consumedResources(), report);
 		if (errors.hasReason())
 			return Maybe.incomplete(assembly, errors.get());
 
@@ -163,6 +163,7 @@ public final class ModeledConfigurationAssembler {
 		}
 
 		Set<ConfigurationKey> keys = new LinkedHashSet<>();
+		Set<String> consumed = new LinkedHashSet<>();
 		List<String> residual = new ArrayList<>();
 		for (String resourceName : resourceNames.stream().sorted().toList()) {
 			if (!resourceName.endsWith(".yaml"))
@@ -171,8 +172,10 @@ public final class ModeledConfigurationAssembler {
 			ParsedName parsed = parse(resourceName, errors);
 			if (parsed == null)
 				continue;
-			if (INFRASTRUCTURE_YAML.contains(parsed.baseName()))
+			if (INFRASTRUCTURE_YAML.contains(parsed.baseName())) {
+				consumed.add(resourceName);
 				continue;
+			}
 
 			List<EntityType<?>> matches = typesByBaseName.get(parsed.baseName());
 			if (matches == null || matches.isEmpty()) {
@@ -187,9 +190,10 @@ public final class ModeledConfigurationAssembler {
 			}
 
 			keys.add(new ConfigurationKey(matches.get(0), parsed.useCase(), parsed.baseName()));
+			consumed.add(resourceName);
 		}
 
-		return new Discovery(keys.stream().sorted().toList(), residual.stream().sorted().toList());
+		return new Discovery(keys.stream().sorted().toList(), Set.copyOf(consumed), residual.stream().sorted().toList());
 	}
 
 	private static ParsedName parse(String resourceName,
@@ -240,6 +244,6 @@ public final class ModeledConfigurationAssembler {
 	private record ParsedName(String baseName, String useCase) {
 	}
 
-	private record Discovery(List<ConfigurationKey> keys, List<String> residualResources) {
+	private record Discovery(List<ConfigurationKey> keys, Set<String> consumedResources, List<String> residualResources) {
 	}
 }

--- a/docs/configuration/configuration-assembly.md
+++ b/docs/configuration/configuration-assembly.md
@@ -2,17 +2,18 @@
 
 ## Motivation
 
-An RX application currently discovers and merges configuration from indexed
-classpath resources, the packaged filesystem mirror and the deployment
-`conf/` directory. This preserves composability, but a terminal application
-build does not yet prove that its packaged configuration is complete.
+An RX application discovers and merges configuration from indexed classpath
+resources and the deployment `conf/` directory. This preserves composability,
+but a terminal application build does not inherently prove that its packaged
+configuration is complete.
 Undeclared placeholders, incompatible fragments or missing sibling
 configuration can consequently remain undetected until the application starts
 or a particular configuration is first used.
 
 The terminal application build should therefore produce and validate an
-explicit static configuration closure. This closure is not a replacement for
-the source resources. It is a reproducible, inspectable view derived from them.
+explicit static configuration closure. This closure is a reproducible,
+inspectable runtime view derived from a separately retained, lossless copy of
+the source resources.
 
 The design has four goals:
 
@@ -24,31 +25,53 @@ The design has four goals:
 
 ## Configuration views
 
-An assembled application exposes three distinct views:
+An assembled application exposes three distinct views and one protocol:
 
 ```text
 application/
-  classpath-resources/     # immutable source/provenance mirror
-  packaged-conf/
-    effective/             # canonical static closure
-    residual/              # configuration assets without an assembler
-    assembly-report.yaml   # origins, imports, coverage and diagnostics
-  conf/                    # deployment overlays
+  packaged-resources/              # complete indexed-resource mirror
+    <artifact-slot>/
+      HICONIC-CONF/...
+      HICONIC-RESOURCES/...
+      ...
+    index.properties               # runtime inventory
+    index.json                     # provenance, digest and disposition
+
+  effective-conf/                  # consumable static configuration closure
+    compiled/
+      <configuration-key>.yaml
+      properties.yaml
+    <artifact-slot>/
+      <unconsumed-config-resource>
+
+  configuration-compilation.yaml   # compilation protocol
+  conf/                            # deployment overlays
 ```
 
-`classpath-resources/` remains suitable for diagnostics and contains the
-unmodified indexed resources grouped by artifact. Successfully assembled
-source entries must, however, be shadowed in the runtime index so that the raw
-fragments and their effective result are not merged twice.
+`packaged-resources/` contains every indexed resource byte-for-byte at its
+canonical classpath-relative path, grouped by artifact. It is both the
+source/provenance view and the filesystem replacement which makes safe eviction
+of explicitly marked pure-resource JARs possible. Unstructured indexed
+resources such as icons and templates remain here and are served directly.
 
-`packaged-conf/effective/` contains one canonical result per configuration key
+`effective-conf/compiled/` contains one canonical result per configuration key
 where the corresponding assembler supports such a representation. A
 configuration key consists at least of configuration kind, modeled type and
 use case.
 
-Assets which cannot yet be assembled stay available below `residual/` with
-their artifact association. They are reported explicitly and retain their
-existing runtime behavior.
+Configuration assets which cannot yet be assembled stay byte-identical in a
+direct artifact slot below `effective-conf/`. The technical `HICONIC-CONF`
+segment is omitted physically and restored logically by the reader. The
+compilation protocol reports these residuals.
+
+At runtime, the existence of `effective-conf/` changes only configuration
+selection: raw `HICONIC-CONF/` entries in `packaged-resources/` are suppressed
+and replaced by the compiled and residual effective slots. All other packaged
+resources remain active. Thus YAML/properties/log configuration may exist in
+both the lossless and effective views without being consumed twice.
+
+`conf/` remains a later, mutable deployment overlay. It is intentionally not
+folded into the packaged static closure.
 
 ## Explicit deployment imports
 
@@ -249,11 +272,10 @@ resolution. This avoids mixing the build-tool classpath with the application
 classpath: the RX application Ant script only launches a forked Java process
 after dependencies and indexed resources have been materialized.
 
-The core implementation and launcher now exist and are tested independently
-of the application Ant script. Activating the launcher in application assembly
-is a separate rollout step: the runtime shadow/index representation must first
-ensure that an effective entry replaces, rather than supplements, its raw
-fragments.
+The core implementation and launcher are invoked by the RX application Ant
+script when the processing dependency is present. The runtime reader combines
+the general packaged-resource source with the direct effective configuration
+slots, replacing rather than supplementing raw configuration fragments.
 
 Configuration type discovery initially maps the canonical kebab-case filename
 to application entity short names:
@@ -267,10 +289,10 @@ and completely explicit without being a prerequisite for the first version.
 
 ## Static and runtime-effective configuration
 
-The first implementation deliberately closes static configuration only:
+The implementation deliberately closes static configuration only:
 
 ```text
-classpath fragments + packaged properties -> effective static configuration
+packaged classpath fragments + packaged properties -> effective static configuration
 ```
 
 Code-registered configuration contributions continue to be applied by the
@@ -331,7 +353,7 @@ coverage become progressively stricter.
 
 ## Implementation status
 
-The first hardened increment provides:
+The hardened increment provides:
 
 - merged and conflict-checked import declarations;
 - closed local property evaluation and tracing of symbolic aliases to their
@@ -341,24 +363,20 @@ The first hardened increment provides:
 - explicit use-case identity and ambiguity detection;
 - undeclared-import and property-cycle failures;
 - explicit separation of deployment imports and platform-supplied variables;
-- canonical effective YAML and assembly-report output;
+- canonical effective YAML and a separate compilation protocol;
 - placeholder-preserving parse/serialize stability checks;
-- a thin application-classpath command-line launcher.
+- residual configuration materialization with artifact provenance;
+- a thin application-classpath command-line launcher;
+- a complete indexed-resource filesystem mirror with a deterministic central
+  runtime index;
+- runtime replacement of raw packaged configuration by `effective-conf`,
+  without affecting unstructured packaged resources.
 
-Residual materialization with full artifact provenance, runtime shadow-index
-activation, further configuration-family assemblers and Ant integration remain
-deliberately outside this increment.
+The RX application Ant script activates that launcher when an application
+carries `configuration-assembly-processing`. Applications without the
+dependency retain the previous assembly behavior. Applications launched from
+an older `classpath-resources`/`packaged-conf` layout remain supported during
+the transition.
 
-## Proposed implementation sequence
-
-1. Model `ConfigurationImports` and the assembly report.
-2. Implement the symbolic property graph and round-trip tests.
-3. Extract modeled YAML discovery, sorting and merging into a reusable
-   assembler.
-4. Test artifact-level validation with synthetic configuration artifacts.
-5. Test terminal closure with multiple artifacts, use cases and imports.
-6. Add residual handling and runtime shadowing.
-7. Invoke the assembly main from the RX application Ant script behind an
-   explicit compatibility switch.
-8. Enable it for one RX application and compare runtime semantics before
-   making it the default.
+Further configuration-family compilers, richer protocol details and
+artifact-level validation remain incremental follow-up work.

--- a/explorer-rx-module/src/hiconic/rx/explorer/processing/platformreflection/PlatformReflectionProcessor.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/processing/platformreflection/PlatformReflectionProcessor.java
@@ -169,8 +169,9 @@ public class PlatformReflectionProcessor extends AbstractDispatchingServiceProce
 	private String zipPassword = "operating";
 
 	private File confFolder = null;
-	private File classpathResourcesFolder;
-	private File packagedConfFolder;
+	private File packagedResourcesFolder;
+	private File effectiveConfFolder;
+	private File configurationCompilationFile;
 	private File dataFolder;
 
 	private StreamPipeFactory streamPipeFactory;
@@ -857,14 +858,17 @@ public class PlatformReflectionProcessor extends AbstractDispatchingServiceProce
 		try {
 			ConfigurationFolder hd = ConfigurationFolder.T.create();
 
-			if (confFolder != null || classpathResourcesFolder != null || packagedConfFolder != null) {
+			if (confFolder != null || packagedResourcesFolder != null || effectiveConfFolder != null
+					|| configurationCompilationFile != null) {
 
 				String filename = "conf-" + now(fileDateTimeFormatter) + ".zip";
 
 				Map<String, File> map = new LinkedHashMap<>();
 				addFolderFiles(map, confFolder, "");
-				addFolderFiles(map, classpathResourcesFolder, "classpath-resources/");
-				addFolderFiles(map, packagedConfFolder, "packaged-conf/");
+				addFolderFiles(map, packagedResourcesFolder, "packaged-resources/");
+				addFolderFiles(map, effectiveConfFolder, "effective-conf/");
+				if (configurationCompilationFile != null && configurationCompilationFile.isFile())
+					map.put("configuration-compilation.yaml", configurationCompilationFile);
 
 				if (!map.isEmpty()) {
 					Resource callResource = Resource
@@ -1546,12 +1550,16 @@ public class PlatformReflectionProcessor extends AbstractDispatchingServiceProce
 		this.confFolder = confFolder;
 	}
 	@Configurable
-	public void setClasspathResourcesFolder(File classpathResourcesFolder) {
-		this.classpathResourcesFolder = classpathResourcesFolder;
+	public void setPackagedResourcesFolder(File packagedResourcesFolder) {
+		this.packagedResourcesFolder = packagedResourcesFolder;
 	}
 	@Configurable
-	public void setPackagedConfFolder(File packagedConfFolder) {
-		this.packagedConfFolder = packagedConfFolder;
+	public void setEffectiveConfFolder(File effectiveConfFolder) {
+		this.effectiveConfFolder = effectiveConfFolder;
+	}
+	@Configurable
+	public void setConfigurationCompilationFile(File configurationCompilationFile) {
+		this.configurationCompilationFile = configurationCompilationFile;
 	}
 	@Configurable
 	public void setDatabaseFolder(File databaseFolder) {

--- a/explorer-rx-module/src/hiconic/rx/explorer/wire/space/PlatformReflectionSpace.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/wire/space/PlatformReflectionSpace.java
@@ -60,8 +60,9 @@ public class PlatformReflectionSpace implements WireSpace {
 		// TODO make zip password configurable
 		bean.setZipPassword(null);
 		bean.setConfFolder(platformResources.confPath().toFile());
-		bean.setClasspathResourcesFolder(platformResources.rootPath().resolve("classpath-resources").toFile());
-		bean.setPackagedConfFolder(platformResources.rootPath().resolve("packaged-conf").toFile());
+		bean.setPackagedResourcesFolder(platformResources.rootPath().resolve("packaged-resources").toFile());
+		bean.setEffectiveConfFolder(platformResources.rootPath().resolve("effective-conf").toFile());
+		bean.setConfigurationCompilationFile(platformResources.rootPath().resolve("configuration-compilation.yaml").toFile());
 		return bean;
 	}
 

--- a/reflex-app-resources/resources/bin/run
+++ b/reflex-app-resources/resources/bin/run
@@ -37,9 +37,11 @@ fi
 # REFLEX_OPTS remains an intentionally late, deployment-specific override/addition.
 read -r -a ENV_JVM_OPTIONS <<< "${REFLEX_OPTS:-}"
 
-CLASSPATH_RESOURCES_OPTIONS=()
-if [ -d "$INST_DIR/classpath-resources" ]; then
-    CLASSPATH_RESOURCES_OPTIONS+=("-Dreflex.classpath.resources.dir=$INST_DIR/classpath-resources")
+PACKAGED_RESOURCES_OPTIONS=()
+if [ -d "$INST_DIR/packaged-resources" ]; then
+    PACKAGED_RESOURCES_OPTIONS+=("-Dreflex.packaged.resources.dir=$INST_DIR/packaged-resources")
+elif [ -d "$INST_DIR/classpath-resources" ]; then
+    PACKAGED_RESOURCES_OPTIONS+=("-Dreflex.classpath.resources.dir=$INST_DIR/classpath-resources")
 fi
 
-"$JAVA_EXECUTABLE" "${PACKAGED_JVM_OPTIONS[@]}" "${ENV_JVM_OPTIONS[@]}" "${CLASSPATH_RESOURCES_OPTIONS[@]}" -Dreflex.app.dir="$INST_DIR" -Dreflex.launch.script="$LAUNCH_SCRIPT" -Djava.net.useSystemProxies=true -jar "$LIB_PATH/launch.jar" "$@"
+"$JAVA_EXECUTABLE" "${PACKAGED_JVM_OPTIONS[@]}" "${ENV_JVM_OPTIONS[@]}" "${PACKAGED_RESOURCES_OPTIONS[@]}" -Dreflex.app.dir="$INST_DIR" -Dreflex.launch.script="$LAUNCH_SCRIPT" -Djava.net.useSystemProxies=true -jar "$LIB_PATH/launch.jar" "$@"

--- a/reflex-app-resources/resources/bin/run.bat
+++ b/reflex-app-resources/resources/bin/run.bat
@@ -31,11 +31,13 @@ if exist "%JVM_OPTIONS_FILE%" (
     for /f "usebackq eol=# delims=" %%O in ("%JVM_OPTIONS_FILE%") do set "PACKAGED_JVM_OPTIONS=!PACKAGED_JVM_OPTIONS! %%O"
 )
 
-set "CLASSPATH_RESOURCES_OPTION="
-if exist "%~dp0\..\classpath-resources\" (
-    set "CLASSPATH_RESOURCES_OPTION=-Dreflex.classpath.resources.dir=%~dp0\..\classpath-resources"
+set "PACKAGED_RESOURCES_OPTION="
+if exist "%~dp0\..\packaged-resources\" (
+    set "PACKAGED_RESOURCES_OPTION=-Dreflex.packaged.resources.dir=%~dp0\..\packaged-resources"
+) else if exist "%~dp0\..\classpath-resources\" (
+    set "PACKAGED_RESOURCES_OPTION=-Dreflex.classpath.resources.dir=%~dp0\..\classpath-resources"
 )
 
-%JAVA_EXECUTABLE% %PACKAGED_JVM_OPTIONS% %REFLEX_OPTS% %CLASSPATH_RESOURCES_OPTION% -Dreflex.app.dir="%~dp0\.." -Dreflex.launch.script=%LAUNCH_SCRIPT% -Djava.net.useSystemProxies=true -jar "%LIB_PATH%\launch.jar" %*
+%JAVA_EXECUTABLE% %PACKAGED_JVM_OPTIONS% %REFLEX_OPTS% %PACKAGED_RESOURCES_OPTION% -Dreflex.app.dir="%~dp0\.." -Dreflex.launch.script=%LAUNCH_SCRIPT% -Djava.net.useSystemProxies=true -jar "%LIB_PATH%\launch.jar" %*
 
 endlocal

--- a/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
+++ b/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
@@ -108,16 +108,26 @@ public class RxPlatform implements AutoCloseable {
 	}
 
 	private ClasspathIndex createClasspathIndex() {
-		String resourcesDir = systemProperties.classpathResourcesDir();
+		String resourcesDir = systemProperties.packagedResourcesDir();
+		if (resourcesDir == null || resourcesDir.isBlank())
+			resourcesDir = systemProperties.classpathResourcesDir();
 		if (resourcesDir == null || resourcesDir.isBlank())
 			return new ClasspathIndex();
 
 		List<ClasspathIndex.FilesystemSource> sources = new ArrayList<>();
-		sources.add(ClasspathIndex.filesystemSource(new File(resourcesDir).toPath(), ""));
+		Path effectiveConfDir = systemProperties.appDir().toPath().resolve("effective-conf");
+		if (Files.isDirectory(effectiveConfDir)) {
+			sources.add(ClasspathIndex.filesystemSource(new File(resourcesDir).toPath(), "",
+					List.of(RxConfigurationConstants.CLASSPATH_CONF_PATH)));
+			sources.add(ClasspathIndex.filesystemSlots(effectiveConfDir, RxConfigurationConstants.CLASSPATH_CONF_PATH));
+		} else {
+			sources.add(ClasspathIndex.filesystemSource(new File(resourcesDir).toPath(), ""));
 
-		Path packagedConfDir = systemProperties.appDir().toPath().resolve("packaged-conf");
-		if (Files.isDirectory(packagedConfDir))
-			sources.add(ClasspathIndex.filesystemSource(packagedConfDir, RxConfigurationConstants.CLASSPATH_CONF_PATH));
+			// Compatibility with the first filesystem projection generation.
+			Path packagedConfDir = systemProperties.appDir().toPath().resolve("packaged-conf");
+			if (Files.isDirectory(packagedConfDir))
+				sources.add(ClasspathIndex.filesystemSource(packagedConfDir, RxConfigurationConstants.CLASSPATH_CONF_PATH));
+		}
 
 		return new ClasspathIndex(sources);
 	}

--- a/reflex-platform/src/hiconic/rx/platform/conf/SystemProperties.java
+++ b/reflex-platform/src/hiconic/rx/platform/conf/SystemProperties.java
@@ -21,6 +21,7 @@ import com.braintribe.wire.api.annotation.Name;
 public interface SystemProperties {
 	static String PROPERTY_APP_DIR = "reflex.app.dir";
 	static String PROPERTY_LAUNCH_SCRIPT = "reflex.launch.script"; 
+	static String PROPERTY_PACKAGED_RESOURCES_DIR = "reflex.packaged.resources.dir";
 	static String PROPERTY_CLASSPATH_RESOURCES_DIR = "reflex.classpath.resources.dir";
 	
 	@Name(PROPERTY_APP_DIR)
@@ -34,4 +35,8 @@ public interface SystemProperties {
 	@Name(PROPERTY_CLASSPATH_RESOURCES_DIR)
 	@Default("")
 	String classpathResourcesDir();
+
+	@Name(PROPERTY_PACKAGED_RESOURCES_DIR)
+	@Default("")
+	String packagedResourcesDir();
 }

--- a/web-server-configuration-model/src/hiconic/rx/web/server/model/config/WebServerConfiguration.java
+++ b/web-server-configuration-model/src/hiconic/rx/web/server/model/config/WebServerConfiguration.java
@@ -34,6 +34,7 @@ public interface WebServerConfiguration extends GenericEntity {
 	String sslKeyStore = "sslKeyStore";
 	String sslKeyStorePassword = "sslKeyStorePassword";
 	String defaultEndpointsBasePath = "defaultEndpointsBasePath";
+	String exposeHealthEndpointsAtDefaultEndpointsBasePath = "exposeHealthEndpointsAtDefaultEndpointsBasePath";
 	String pushSseEndpointPath = "pushSseEndpointPath";
 	String pushWebSocketEndpointPath = "pushWebSocketEndpointPath";
 
@@ -79,6 +80,13 @@ public interface WebServerConfiguration extends GenericEntity {
 	@Pattern(".*[^\\/]$")
 	String getDefaultEndpointsBasePath();
 	void setDefaultEndpointsBasePath(String defaultEndpointsBasePath);
+
+	@Description("If true, the canonical /livez and /readyz endpoints are additionally exposed below defaultEndpointsBasePath. "
+			+ "The aliases are handled by the application-state gate before endpoint/servlet dispatch and therefore retain the canonical "
+			+ "bootstrap and readiness semantics.")
+	@Initializer("false")
+	boolean getExposeHealthEndpointsAtDefaultEndpointsBasePath();
+	void setExposeHealthEndpointsAtDefaultEndpointsBasePath(boolean exposeHealthEndpointsAtDefaultEndpointsBasePath);
 
 	@Description("Path of the SSE transport endpoint for platform push, relative to defaultEndpointsBasePath. The value must not end with '/'.")
 	@Pattern(".*[^\\/]$")

--- a/web-server-rx-module/src/hiconic/platform/reflex/web_server/processing/ApplicationStateGateHandler.java
+++ b/web-server-rx-module/src/hiconic/platform/reflex/web_server/processing/ApplicationStateGateHandler.java
@@ -6,23 +6,46 @@ import io.undertow.server.HttpServerExchange;
 
 public class ApplicationStateGateHandler implements HttpHandler {
 
+	private static final String LIVENESS_PATH = "/livez";
+	private static final String READINESS_PATH = "/readyz";
+
 	private final BlockingHolder<HttpHandler> standardHandler = new BlockingHolder<>();
 	private final RxApplicationStateManager stateManager;
+	private final String livenessPathAlias;
+	private final String readinessPathAlias;
 	
 	public ApplicationStateGateHandler(RxApplicationStateManager stateManager) {
+		this(stateManager, null);
+	}
+
+	public ApplicationStateGateHandler(RxApplicationStateManager stateManager, String healthEndpointAliasBasePath) {
 		super();
 		this.stateManager = stateManager;
+		this.livenessPathAlias = aliasPath(healthEndpointAliasBasePath, LIVENESS_PATH);
+		this.readinessPathAlias = aliasPath(healthEndpointAliasBasePath, READINESS_PATH);
 	}
 
 	@Override
 	public void handleRequest(HttpServerExchange exchange) throws Exception {
 		String path = exchange.getRelativePath();
 		
-		switch (path) {
-		case "/livez" -> handleLivez(exchange);
-		case "/readyz" -> handleReadyz(exchange);
-		default -> handleStandardRequest(exchange);
-		}
+		if (LIVENESS_PATH.equals(path) || livenessPathAlias != null && livenessPathAlias.equals(path))
+			handleLivez(exchange);
+		else if (READINESS_PATH.equals(path) || readinessPathAlias != null && readinessPathAlias.equals(path))
+			handleReadyz(exchange);
+		else
+			handleStandardRequest(exchange);
+	}
+
+	private static String aliasPath(String basePath, String canonicalPath) {
+		if (basePath == null || basePath.isBlank() || "/".equals(basePath))
+			return null;
+
+		String normalizedBasePath = basePath.startsWith("/") ? basePath : "/" + basePath;
+		while (normalizedBasePath.endsWith("/"))
+			normalizedBasePath = normalizedBasePath.substring(0, normalizedBasePath.length() - 1);
+
+		return normalizedBasePath + canonicalPath;
 	}
 	
 	private void handleStandardRequest(HttpServerExchange exchange) throws Exception {

--- a/web-server-rx-module/src/hiconic/platform/reflex/web_server/wire/space/WebServerRxModuleSpace.java
+++ b/web-server-rx-module/src/hiconic/platform/reflex/web_server/wire/space/WebServerRxModuleSpace.java
@@ -478,7 +478,11 @@ public class WebServerRxModuleSpace implements RxModuleContract, WebServerContra
 
 	@Managed
 	private ApplicationStateGateHandler applicationStateGateHandler() {
-		ApplicationStateGateHandler bean = new ApplicationStateGateHandler(platform.application().stateManager());
+		WebServerConfiguration configuration = configuration();
+		String healthEndpointAliasBasePath = configuration.getExposeHealthEndpointsAtDefaultEndpointsBasePath()
+				? defaultEndpointsBasePath()
+				: null;
+		ApplicationStateGateHandler bean = new ApplicationStateGateHandler(platform.application().stateManager(), healthEndpointAliasBasePath);
 		return bean;
 	}
 


### PR DESCRIPTION
## Summary
- compile modeled configuration and properties into effective-conf/compiled
- retain uncompiled configuration resources in artifact-scoped effective slots
- serve general indexed resources from packaged-resources while replacing only raw HICONIC-CONF
- add launcher support, diagnostics, compilation protocol and legacy fallbacks
- expose optional health endpoint aliases below the configured default endpoint base path

## Verification
- configuration assembly processing and tests compile
- all configuration assembly tests pass
- reflex-platform and explorer-rx-module compile
- launcher shell syntax validates
- combined packaged/effective reader semantics are covered in GM tests