### PR TITLE
Manage platform configuration properties explicitly

### DIFF
--- a/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
+++ b/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
@@ -25,6 +25,7 @@ import java.lang.System.Logger.Level;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -70,6 +71,7 @@ public class RxPlatform implements AutoCloseable {
 	private final ApplicationProperties applicationProperties;
 	private final ClasspathIndex classpathIndex;
 	private final RxPropertyResolver propertyResolver;
+	private final Map<String, String> managedPropertyOverrides;
 
 	private final String[] args;
 
@@ -88,16 +90,28 @@ public class RxPlatform implements AutoCloseable {
 		this(//
 				args, //
 				defaultSystemPropertyLookup(), //
-				defaultApplicationPropertyLookup() //
+				defaultApplicationPropertyLookup(), //
+				Map.of() //
 		);
 	}
 
 	public RxPlatform(Function<String, String> systemPropertyLookup, Function<String, String> applicationPropertyLookup) {
-		this(new String[] {}, systemPropertyLookup, applicationPropertyLookup);
+		this(new String[] {}, systemPropertyLookup, applicationPropertyLookup, Map.of());
 	}
 
 	public RxPlatform(String[] args, Function<String, String> systemPropertyLookup, Function<String, String> applicationPropertyLookup) {
+		this(args, systemPropertyLookup, applicationPropertyLookup, Map.of());
+	}
+
+	/**
+	 * Starts a platform with explicit values added to the managed configuration property graph.
+	 * <p>
+	 * This is primarily useful to embedders and test harnesses. It does not restore the legacy implicit environment fallback.
+	 */
+	public RxPlatform(String[] args, Function<String, String> systemPropertyLookup, Function<String, String> applicationPropertyLookup,
+			Map<String, String> managedPropertyOverrides) {
 		this.args = args;
+		this.managedPropertyOverrides = Map.copyOf(managedPropertyOverrides);
 		
 		systemProperties = PropertyLookups.create(SystemProperties.class, systemPropertyLookup);
 		applicationProperties = PropertyLookups.create(ApplicationProperties.class, applicationPropertyLookup);
@@ -279,6 +293,9 @@ public class RxPlatform implements AutoCloseable {
 		File confDir = new File(systemProperties.appDir(), "conf");
 		Map<String, String> rawProperties = UnsatisfiedMaybeTunneling.getOrTunnel(
 				RxPropertiesLoader.loadLayered(confDir, RxConfigurationConstants.CLASSPATH_CONF_PATH, "properties", new YamlMarshaller(), classpathIndex));
+		rawProperties = new LinkedHashMap<>(rawProperties);
+		rawProperties.putIfAbsent(SystemProperties.PROPERTY_APP_DIR, systemProperties.appDir().getPath());
+		rawProperties.putAll(managedPropertyOverrides);
 
 		ConfigurationImportDeclarations imports = UnsatisfiedMaybeTunneling.getOrTunnel(
 				ConfigurationImportDeclarations.read(classpathIndex));

--- a/reflex-test-commons/src/hiconic/rx/test/common/AbstractRxTest.java
+++ b/reflex-test-commons/src/hiconic/rx/test/common/AbstractRxTest.java
@@ -13,6 +13,7 @@
 // ============================================================================
 package hiconic.rx.test.common;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.After;
@@ -37,7 +38,8 @@ public abstract class AbstractRxTest {
 	@Before
 	public void onBefore() {
 		try {
-			platform = loadPlatform(AbstractRxTest.this.getClass().getSimpleName());
+			platform = new RxPlatform(new String[] {}, systemPropertyLookup("res/app"),
+					applicationPropertyLookup(AbstractRxTest.this.getClass().getSimpleName()), managedPropertyOverrides());
 			platformContract = platform.getContract();
 			evaluator = platform.getContract().serviceProcessing().evaluator();
 
@@ -67,6 +69,10 @@ public abstract class AbstractRxTest {
 
 	protected <C extends RxExportContract> C resolveExportContract(Class<C> contractClass) {
 		return platform.getWireContext().contract(contractClass);
+	}
+
+	protected Map<String, String> managedPropertyOverrides() {
+		return Map.of();
 	}
 
 	//


### PR DESCRIPTION
Adds platform-owned configuration values and an explicit test/embedder override hook without restoring implicit environment fallback. This lets strict managed configuration retain reflex.app.dir and deliberate test database identities.