### PR TITLE
Model Undertow connection capacity

### DIFF
--- a/web-server-configuration-model/src/hiconic/rx/web/server/model/config/WebServerConfiguration.java
+++ b/web-server-configuration-model/src/hiconic/rx/web/server/model/config/WebServerConfiguration.java
@@ -31,6 +31,7 @@ public interface WebServerConfiguration extends GenericEntity {
 	String maxTreads = "maxThreads";
 	String coreTreads = "coreThreads";
 	String ioTreads = "ioThreads";
+	String maxConnections = "maxConnections";
 	String sslKeyStore = "sslKeyStore";
 	String sslKeyStorePassword = "sslKeyStorePassword";
 	String defaultEndpointsBasePath = "defaultEndpointsBasePath";
@@ -58,14 +59,23 @@ public interface WebServerConfiguration extends GenericEntity {
 	String getSslKeyStorePassword();
 	void setSslKeyStorePassword(String sslKeyStorePassword);
 
+	@Description("Number of XNIO I/O threads. These threads accept connections and perform non-blocking socket I/O; "
+			+ "blocking application work is dispatched to the worker task pool.")
 	Integer getIoThreads();
 	void setIoThreads(Integer ioThreads);
 
+	@Description("Maximum number of threads in Undertow's worker task pool for blocking application work.")
 	Integer getMaxThreads();
 	void setMaxThreads(Integer maxThreads);
 
+	@Description("Core number of threads retained in Undertow's worker task pool for blocking application work.")
 	Integer getCoreThreads();
 	void setCoreThreads(Integer coreThreads);
+
+	@Description("Maximum number of concurrently accepted connections. Once reached, Undertow suspends accepts until "
+			+ "the active connection count falls below the limit.")
+	Integer getMaxConnections();
+	void setMaxConnections(Integer maxConnections);
 
 	CorsConfiguration getCorsConfiguration();
 	void setCorsConfiguration(CorsConfiguration corsConfiguration);

--- a/web-server-rx-module/src/hiconic/platform/reflex/web_server/wire/space/WebServerRxModuleSpace.java
+++ b/web-server-rx-module/src/hiconic/platform/reflex/web_server/wire/space/WebServerRxModuleSpace.java
@@ -506,6 +506,14 @@ public class WebServerRxModuleSpace implements RxModuleContract, WebServerContra
 		if (maxThreads != null)
 			builder.setWorkerOption(Options.WORKER_TASK_MAX_THREADS, maxThreads);
 
+		Integer maxConnections = configuration.getMaxConnections();
+		if (maxConnections != null) {
+			// XNIO uses a high/low watermark pair to suspend and resume accepts.
+			// Equal values model a strict maximum without an arbitrary hysteresis band.
+			builder.setWorkerOption(Options.CONNECTION_HIGH_WATER, maxConnections);
+			builder.setWorkerOption(Options.CONNECTION_LOW_WATER, maxConnections);
+		}
+
 		SslConfig sslConfig = sslConfigBox().value;
 		if (sslConfig != null)
 			builder.addHttpsListener(sslConfig.port(), "0.0.0.0", sslConfig.sslContext());


### PR DESCRIPTION
Makes the existing Undertow thread settings explicit in the modeled configuration and adds a real maxConnections setting. XNIO high/low connection watermarks enforce the configured limit without confusing connection capacity with the accept backlog.