### PR TITLE
Generate portable classpath resource indices

### DIFF
--- a/classpath-index-ant.xml
+++ b/classpath-index-ant.xml
@@ -4,7 +4,7 @@
 		<mkdir dir="src/META-INF"/>
 		<delete file="src/META-INF/classpath-resource-only" quiet="true"/>
 		<delete file="build/META-INF/classpath-resource-only" quiet="true"/>
-		<pathconvert property="classpath.index.entries" pathsep="${line.separator}">
+		<pathconvert property="classpath.index.entries" pathsep="${line.separator}" targetos="unix">
 			<fileset dir="src">
 				<include name="**/*"/>
 				<exclude name="**/*.java"/>


### PR DESCRIPTION
Force classpath resource indices to use canonical forward slashes on every build host.