### PR TITLE
Close SSE and MIME enrichment lifecycle gaps

### DIFF
--- a/classpath-index-ant.xml
+++ b/classpath-index-ant.xml
@@ -8,6 +8,7 @@
 			<fileset dir="src">
 				<include name="**/*"/>
 				<exclude name="**/*.java"/>
+				<exclude name="**/.gitignore"/>
 				<exclude name="META-INF/classpath-index.txt"/>
 				<exclude name="META-INF/classpath-resource-only"/>
 			</fileset>
@@ -17,19 +18,36 @@
 	</target>
 
 	<!-- Eclipse consumes project resources from its output directory. Writing there avoids changing/refreshing src and recursively triggering this builder. -->
-	<target name="generate-eclipse-classpath-index">
+	<target name="prepare-eclipse-classpath-index">
 		<property name="eclipse.output.dir" value="classes"/>
 		<mkdir dir="${eclipse.output.dir}/META-INF"/>
+		<tempfile property="eclipse.classpath.index.tmp" destdir="${java.io.tmpdir}" prefix="classpath-index-" suffix=".txt" deleteonexit="true"/>
 		<pathconvert property="classpath.index.entries" pathsep="${line.separator}" targetos="unix">
 			<fileset dir="src">
 				<include name="**/*"/>
 				<exclude name="**/*.java"/>
+				<exclude name="**/.gitignore"/>
 				<exclude name="META-INF/classpath-index.txt"/>
 				<exclude name="META-INF/classpath-resource-only"/>
 			</fileset>
 			<map from="${basedir}/src/" to=""/>
 		</pathconvert>
-		<echo file="${eclipse.output.dir}/META-INF/classpath-index.txt">${classpath.index.entries}${line.separator}</echo>
+		<echo file="${eclipse.classpath.index.tmp}">${classpath.index.entries}${line.separator}</echo>
+		<condition property="eclipse.classpath.index.unchanged">
+			<and>
+				<available file="${eclipse.output.dir}/META-INF/classpath-index.txt"/>
+				<filesmatch file1="${eclipse.output.dir}/META-INF/classpath-index.txt" file2="${eclipse.classpath.index.tmp}"/>
+			</and>
+		</condition>
+	</target>
+
+	<!-- Avoid timestamp-only workspace deltas which recursively schedule the incremental builder. -->
+	<target name="update-eclipse-classpath-index" depends="prepare-eclipse-classpath-index" unless="eclipse.classpath.index.unchanged">
+		<copy file="${eclipse.classpath.index.tmp}" tofile="${eclipse.output.dir}/META-INF/classpath-index.txt" overwrite="true"/>
+	</target>
+
+	<target name="generate-eclipse-classpath-index" depends="update-eclipse-classpath-index">
+		<delete file="${eclipse.classpath.index.tmp}" quiet="true"/>
 	</target>
 
 	<target name="generate-pure-classpath-index" depends="generate-classpath-index">

--- a/explorer-web-resources/.externalToolBuilders/Build Classpath Index.launch
+++ b/explorer-web-resources/.externalToolBuilders/Build Classpath Index.launch
@@ -10,7 +10,7 @@
     <stringAttribute key="process_factory_id" value="org.eclipse.ant.ui.remoteAntProcessFactory"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="explorer-web-resources - hiconic.platform.reflex"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${project_loc:explorer-web-resources - hiconic.platform.reflex}/build-index.xml"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,"/>
     <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${project_loc:explorer-web-resources - hiconic.platform.reflex}"/>
 </launchConfiguration>

--- a/explorer-web-resources/.project
+++ b/explorer-web-resources/.project
@@ -15,16 +15,6 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
-			<triggers>full,incremental,</triggers>
-			<arguments>
-				<dictionary>
-					<key>LaunchConfigHandle</key>
-					<value>&lt;project&gt;/.externalToolBuilders/Build Classpath Index.launch</value>
-				</dictionary>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/reflex-app-resources/.classpath
+++ b/reflex-app-resources/.classpath
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
-	<classpathentry exported="true" kind="lib" path="class-gen"/>
-	<classpathentry kind="output" path="classes"/>
-</classpath>

--- a/reflex-app-resources/.project
+++ b/reflex-app-resources/.project
@@ -2,17 +2,4 @@
 
 <projectDescription>
 	<name>reflex-app-resources - hiconic.platform.reflex</name>
-	<buildSpec>
-		<buildCommand>
-			<name>com.braintribe.devrock.arb.builder.ArtifactReflectionBuilder</name>
-			<arguments/>
-		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments/>
-		</buildCommand>
-	</buildSpec>
-	<natures>
-		<nature>org.eclipse.jdt.core.javanature</nature>
-	</natures>
 </projectDescription>

--- a/reflex-platform-test/src/hiconic/rx/platform/conf/DelegatingMimeTypeDetectorTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/conf/DelegatingMimeTypeDetectorTest.java
@@ -1,0 +1,54 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.conf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.braintribe.mimetype.MimeTypeDetector;
+import com.braintribe.provider.Box;
+
+public class DelegatingMimeTypeDetectorTest {
+
+	@Test
+	public void existingFacadeUsesDetectorContributedLater() {
+		Box<MimeTypeDetector> delegate = Box.of(detector("initial/type"));
+		MimeTypeDetector facade = new DelegatingMimeTypeDetector(() -> delegate.value);
+
+		assertThat(facade.getMimeType((InputStream) null, "sample.bin")).isEqualTo("initial/type");
+
+		delegate.value = detector("contributed/type");
+
+		assertThat(facade.getMimeType((InputStream) null, "sample.bin")).isEqualTo("contributed/type");
+		assertThat(facade.getMimeType((File) null, "sample.bin")).isEqualTo("contributed/type");
+	}
+
+	private static MimeTypeDetector detector(String mimeType) {
+		return new MimeTypeDetector() {
+			@Override
+			public String getMimeType(File file, String fileName) {
+				return mimeType;
+			}
+
+			@Override
+			public String getMimeType(InputStream inputStream, String fileName) {
+				return mimeType;
+			}
+		};
+	}
+}

--- a/reflex-platform/src/hiconic/rx/platform/conf/DelegatingMimeTypeDetector.java
+++ b/reflex-platform/src/hiconic/rx/platform/conf/DelegatingMimeTypeDetector.java
@@ -1,0 +1,51 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.conf;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+import com.braintribe.mimetype.MimeTypeDetector;
+
+/**
+ * Stable {@link MimeTypeDetector} facade whose delegate may be contributed later during RX platform configuration.
+ * <p>
+ * Model configuration happens before the platform configuration phase. Components created while models are configured
+ * must therefore retain this facade rather than the detector which happened to be configured at that time.
+ */
+public final class DelegatingMimeTypeDetector implements MimeTypeDetector {
+
+	private final Supplier<? extends MimeTypeDetector> delegateSupplier;
+
+	public DelegatingMimeTypeDetector(Supplier<? extends MimeTypeDetector> delegateSupplier) {
+		this.delegateSupplier = requireNonNull(delegateSupplier, "delegateSupplier");
+	}
+
+	@Override
+	public String getMimeType(File file, String fileName) throws RuntimeException {
+		return delegate().getMimeType(file, fileName);
+	}
+
+	@Override
+	public String getMimeType(InputStream inputStream, String fileName) {
+		return delegate().getMimeType(inputStream, fileName);
+	}
+
+	private MimeTypeDetector delegate() {
+		return requireNonNull(delegateSupplier.get(), "No MIME type detector configured");
+	}
+}

--- a/reflex-platform/src/hiconic/rx/platform/wire/space/RxTransientDataSpace.java
+++ b/reflex-platform/src/hiconic/rx/platform/wire/space/RxTransientDataSpace.java
@@ -28,6 +28,7 @@ import com.braintribe.utils.stream.pools.SmartBlockPoolFactory;
 import com.braintribe.wire.api.annotation.Managed;
 
 import hiconic.rx.module.api.wire.RxTransientDataContract;
+import hiconic.rx.platform.conf.DelegatingMimeTypeDetector;
 
 /**
  * 
@@ -69,8 +70,10 @@ public class RxTransientDataSpace implements RxTransientDataContract {
 	}
 
 	@Override
+	@Managed
 	public MimeTypeDetector mimeTypeDetector() {
-		return mimeTypeDetectorHolder().value;
+		Box<MimeTypeDetector> holder = mimeTypeDetectorHolder();
+		return new DelegatingMimeTypeDetector(() -> holder.value);
 	}
 
 	@Managed

--- a/web-server-rx-module/src/hiconic/platform/reflex/web_server/processing/SsePushServlet.java
+++ b/web-server-rx-module/src/hiconic/platform/reflex/web_server/processing/SsePushServlet.java
@@ -30,6 +30,7 @@ import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.eval.Evaluator;
 import com.braintribe.model.processing.service.api.ServiceProcessor;
 import com.braintribe.model.processing.service.api.ServiceRequestContext;
+import com.braintribe.model.processing.service.common.context.UserSessionAspect;
 import com.braintribe.model.securityservice.ValidateUserSession;
 import com.braintribe.model.service.api.InstanceId;
 import com.braintribe.model.service.api.InternalPushRequest;
@@ -37,6 +38,7 @@ import com.braintribe.model.service.api.ServiceRequest;
 import com.braintribe.model.service.api.result.PushResponse;
 import com.braintribe.model.service.api.result.PushResponseMessage;
 import com.braintribe.model.usersession.UserSession;
+import com.braintribe.utils.collection.impl.AttributeContexts;
 
 import hiconic.rx.push.api.PushChannel;
 import hiconic.rx.push.api.PushContract;
@@ -82,23 +84,27 @@ public class SsePushServlet extends HttpServlet implements ServiceProcessor<Inte
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		String clientId = request.getParameter("clientId");
-		if (clientId == null || clientId.isBlank()) {
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "A clientId is required to open an SSE connection.");
-			return;
-		}
+		if (clientId != null && clientId.isBlank())
+			clientId = null;
 
 		String accept = request.getParameter("accept");
 		if (accept == null || accept.isBlank())
 			accept = "application/json";
 		if (marshallerRegistry.getMarshaller(accept) == null) {
+			log.debug("Rejected SSE connection because the requested payload format is unsupported.");
 			response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE, "Unsupported payload format: " + accept);
 			return;
 		}
 
-		String sessionId = request.getParameter("sessionId");
-		UserSession userSession = validateSession(sessionId, response);
-		if (sessionId != null && userSession == null)
+		String requestedSessionId = request.getParameter("sessionId");
+		boolean explicitSession = requestedSessionId != null && !requestedSessionId.isBlank();
+		UserSession userSession = !explicitSession
+				? AttributeContexts.peek().findOrNull(UserSessionAspect.class)
+				: validateSession(requestedSessionId, response);
+		if (explicitSession && userSession == null)
 			return;
+		String sessionId = userSession == null ? null : userSession.getSessionId();
+		String sessionSource = explicitSession ? "explicit" : userSession == null ? "none" : "web-auth-context";
 
 		response.setStatus(HttpServletResponse.SC_OK);
 		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
@@ -115,6 +121,10 @@ public class SsePushServlet extends HttpServlet implements ServiceProcessor<Inte
 		push.registerChannel(channel);
 
 		channel.send("channel", channel.getChannelId());
+		boolean identifiedClient = clientId != null;
+		String payloadFormat = accept;
+		log.debug(() -> "Opened SSE channel (identifiedClient=" + identifiedClient + ", sessionSource=" + sessionSource
+				+ ", payloadFormat=" + payloadFormat + ", activeChannels=" + channels.size() + ")");
 	}
 
 	private UserSession validateSession(String sessionId, HttpServletResponse response) throws IOException {
@@ -127,6 +137,7 @@ public class SsePushServlet extends HttpServlet implements ServiceProcessor<Inte
 		if (maybe.isSatisfied())
 			return maybe.get();
 
+		log.debug("Rejected SSE connection because the explicitly supplied session is invalid.");
 		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "The provided session ID is invalid.");
 		return null;
 	}
@@ -233,6 +244,7 @@ public class SsePushServlet extends HttpServlet implements ServiceProcessor<Inte
 				return;
 			channels.remove(channelId, this);
 			push.unregisterChannel(this);
+			log.debug(() -> "Closed SSE channel (activeChannels=" + channels.size() + ")");
 			try {
 				async.complete();
 			} catch (IllegalStateException ignored) {

--- a/websocket-server-rx-module-test/src/hiconic/rx/websocket/module/test/SsePushTest.java
+++ b/websocket-server-rx-module-test/src/hiconic/rx/websocket/module/test/SsePushTest.java
@@ -27,6 +27,19 @@ import hiconic.rx.test.common.AbstractRxTest;
 import hiconic.rx.web.server.api.WebServerContract;
 
 public class SsePushTest extends AbstractRxTest {
+	@Test
+	public void acceptsAnonymousSseConnection() throws Exception {
+		WebServerContract webServer = platform.getWireContext().contract(WebServerContract.class);
+		URI uri = URI.create("http://localhost:" + webServer.getEffectiveServerPort() + "/push/sse");
+
+		HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+		HttpResponse<InputStream> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofInputStream());
+		Assertions.assertThat(response.statusCode()).isEqualTo(200);
+		try (InputStream stream = response.body();
+				BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+			Assertions.assertThat(readEvent(reader)).contains("event: channel", "data: ");
+		}
+	}
 
 	@Test
 	public void receivesPushViaSse() throws Exception {


### PR DESCRIPTION
Summary:
- keep the platform MIME detector as a stable delegating facade so late RX contributions reach already configured resource enrichers
- accept SSE sessions propagated by the web authentication context and retain explicit-session validation
- prevent Eclipse resource-index builders from recursively retriggering and remove Java descriptors from a pure resource artifact

Evidence:
- reflex-platform-test: all tests successful, including late MIME detector contribution
- websocket-server-rx-module-test: all tests successful, including anonymous/context-compatible SSE channel opening
- git diff --check

Compatibility:
The MIME change preserves the existing default detector and only makes later platform contributions visible. Explicit SSE session IDs retain validation; contextual web sessions are additionally supported.