### PR TITLE
Emit canonical YAML for OpenAPI exports

### DIFF
--- a/openapi-v3-api-model/src/com/braintribe/model/openapi/v3_0/api/OpenapiEntitiesRequest.java
+++ b/openapi-v3-api-model/src/com/braintribe/model/openapi/v3_0/api/OpenapiEntitiesRequest.java
@@ -22,9 +22,14 @@ import com.braintribe.model.generic.reflection.EntityTypes;
 import com.braintribe.model.openapi.v3_0.OpenApi;
 import com.braintribe.model.service.api.ServiceRequest;
 
+import hiconic.rx.webapi.endpoints.TypeExplicitness;
 import hiconic.rx.webapi.model.annotation.RequestPath;
+import hiconic.rx.webapi.model.annotation.ResponseMimeType;
+import hiconic.rx.webapi.model.annotation.ResponseTypeExplicitness;
 
 @RequestPath("entities")
+@ResponseMimeType("text/yaml")
+@ResponseTypeExplicitness(TypeExplicitness.never)
 public interface OpenapiEntitiesRequest extends OpenapiCrudRequest {
 
 	EntityType<OpenapiEntitiesRequest> T = EntityTypes.T(OpenapiEntitiesRequest.class);

--- a/openapi-v3-api-model/src/com/braintribe/model/openapi/v3_0/api/OpenapiPropertiesRequest.java
+++ b/openapi-v3-api-model/src/com/braintribe/model/openapi/v3_0/api/OpenapiPropertiesRequest.java
@@ -22,9 +22,14 @@ import com.braintribe.model.generic.reflection.EntityTypes;
 import com.braintribe.model.openapi.v3_0.OpenApi;
 import com.braintribe.model.service.api.ServiceRequest;
 
+import hiconic.rx.webapi.endpoints.TypeExplicitness;
 import hiconic.rx.webapi.model.annotation.RequestPath;
+import hiconic.rx.webapi.model.annotation.ResponseMimeType;
+import hiconic.rx.webapi.model.annotation.ResponseTypeExplicitness;
 
 @RequestPath("properties")
+@ResponseMimeType("text/yaml")
+@ResponseTypeExplicitness(TypeExplicitness.never)
 public interface OpenapiPropertiesRequest extends OpenapiCrudRequest {
 
 	EntityType<OpenapiPropertiesRequest> T = EntityTypes.T(OpenapiPropertiesRequest.class);

--- a/openapi-v3-api-model/src/com/braintribe/model/openapi/v3_0/api/OpenapiServicesRequest.java
+++ b/openapi-v3-api-model/src/com/braintribe/model/openapi/v3_0/api/OpenapiServicesRequest.java
@@ -24,9 +24,14 @@ import com.braintribe.model.generic.reflection.EntityTypes;
 import com.braintribe.model.openapi.v3_0.OpenApi;
 import com.braintribe.model.service.api.ServiceRequest;
 
+import hiconic.rx.webapi.endpoints.TypeExplicitness;
 import hiconic.rx.webapi.model.annotation.RequestPath;
+import hiconic.rx.webapi.model.annotation.ResponseMimeType;
+import hiconic.rx.webapi.model.annotation.ResponseTypeExplicitness;
 
 @RequestPath("services")
+@ResponseMimeType("text/yaml")
+@ResponseTypeExplicitness(TypeExplicitness.never)
 public interface OpenapiServicesRequest extends OpenapiRequest {
 
 	EntityType<OpenapiServicesRequest> T = EntityTypes.T(OpenapiServicesRequest.class);

--- a/web-api-mapping-meta-data-model/src/META-INF/gmf.mda
+++ b/web-api-mapping-meta-data-model/src/META-INF/gmf.mda
@@ -6,6 +6,7 @@ hiconic.rx.webapi.model.annotation.ResponseProjection,hiconic.rx.webapi.model.me
 hiconic.rx.webapi.model.annotation.ResponseMimeType,hiconic.rx.webapi.model.meta.ResponseMimeType,value,mimeType
 hiconic.rx.webapi.model.annotation.ResponseDepth,hiconic.rx.webapi.model.meta.ResponseDepth,value,depth
 hiconic.rx.webapi.model.annotation.ResponseEntityRecurrenceDepth,hiconic.rx.webapi.model.meta.ResponseEntityRecurrenceDepth,value,depth
+hiconic.rx.webapi.model.annotation.ResponseTypeExplicitness,hiconic.rx.webapi.model.meta.ResponseTypeExplicitness,value,typeExplicitness
 hiconic.rx.webapi.model.annotation.RequestDecodingLenience,hiconic.rx.webapi.model.meta.RequestDecodingLenience,value,active
 hiconic.rx.webapi.model.annotation.ResponseAsResourcePayload,hiconic.rx.webapi.model.meta.ResponseAsResourcePayload
 hiconic.rx.webapi.model.annotation.ResponseWithDownloadDialog,hiconic.rx.webapi.model.meta.ResponseWithDownloadDialog

--- a/web-api-mapping-meta-data-model/src/hiconic/rx/webapi/model/annotation/ResponseTypeExplicitness.java
+++ b/web-api-mapping-meta-data-model/src/hiconic/rx/webapi/model/annotation/ResponseTypeExplicitness.java
@@ -1,0 +1,31 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.webapi.model.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import hiconic.rx.webapi.endpoints.TypeExplicitness;
+
+/** Annotation for {@link hiconic.rx.webapi.model.meta.ResponseTypeExplicitness}. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface ResponseTypeExplicitness {
+	String globalId() default "";
+	TypeExplicitness value();
+}


### PR DESCRIPTION
## Summary
- add annotation support for response type explicitness
- export OpenAPI YAML without GM type tags
- preserve the canonical `text/yaml` response for services, entities, and properties schemas

## Verification
- compiled and installed both affected model artifacts
- assembled and started `proventem-rx-local-app`
- fetched the object-store OpenAPI document through the live DDRA endpoint
- parsed the resulting YAML successfully (`openapi: 3.0.1`, 43 paths, 72 schemas)