### PR TITLE
Keep domain inference isolated per request

### DIFF
--- a/reflex-platform-test/src/hiconic/rx/platform/service/ServiceDomainRoleGuardTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/service/ServiceDomainRoleGuardTest.java
@@ -13,12 +13,15 @@
 // ============================================================================
 package hiconic.rx.platform.service;
 
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import com.braintribe.gm.model.reason.Maybe;
 import com.braintribe.gm.model.security.reason.Forbidden;
 import com.braintribe.model.resource.source.FileSystemSource;
+import com.braintribe.model.service.api.CompositeRequest;
 import com.braintribe.model.service.api.InstanceId;
 import com.braintribe.model.service.api.MulticastRequest;
 import com.braintribe.model.service.api.result.MulticastResponse;
@@ -26,6 +29,7 @@ import com.braintribe.model.service.api.result.MulticastResponse;
 import hiconic.rx.resource.model.api.GetResourcePayload;
 import hiconic.rx.model.service.processing.md.ProcessWith;
 import hiconic.rx.module.api.service.PlatformServiceDomains;
+import hiconic.rx.module.api.service.ServiceDomain;
 import hiconic.rx.platform.test.PlatformTestDomains;
 import hiconic.rx.platform.test.wire.space.PlatformRxTestModuleSpace;
 import hiconic.rx.test.common.AbstractRxTest;
@@ -61,6 +65,18 @@ public class ServiceDomainRoleGuardTest extends AbstractRxTest {
 				.getMetaData().entityType(MulticastRequest.T).meta(ProcessWith.T).exclusive();
 		Assertions.assertThat(effectiveBinding).isNotNull();
 		Assertions.assertThat(effectiveBinding.getConflictPriority()).isEqualTo(0d);
+	}
+
+	@Test
+	public void domainInferenceDoesNotMutateSharedDomainIndex() {
+		var serviceDomains = platformContract.serviceProcessing().serviceDomains();
+		List<? extends ServiceDomain> domainsBefore = List.copyOf(serviceDomains.listDomains(CompositeRequest.T));
+
+		CompositeRequest request = CompositeRequest.T.create();
+		request.setRequests(List.of(multicastRequest()));
+
+		request.eval(platformContract.serviceProcessing().systemEvaluator()).getReasoned();
+		Assertions.assertThat(serviceDomains.listDomains(CompositeRequest.T)).containsExactlyElementsOf(domainsBefore);
 	}
 
 	private MulticastRequest multicastRequest() {

--- a/reflex-platform/src/hiconic/rx/platform/service/RxServiceDomainDispatcher.java
+++ b/reflex-platform/src/hiconic/rx/platform/service/RxServiceDomainDispatcher.java
@@ -107,7 +107,11 @@ public class RxServiceDomainDispatcher
 			List<? extends ServiceDomain> dependers = serviceDomains.listDomains(requestType);
 
 			if (dependers.size() != 1)
-				dependers.removeIf(domain -> !domainProcessesRequest(domain, requestType));
+				// The domain index owns and shares this list across evaluations. Filtering it in place corrupts the index and races
+				// with concurrent requests (for example the browser's parallel session bootstrap calls).
+				dependers = dependers.stream() //
+						.filter(domain -> domainProcessesRequest(domain, requestType)) //
+						.toList();
 
 			if (dependers.size() != 1)
 				return wrongNumberOfDependers(dependers, requestType);


### PR DESCRIPTION
## Summary
- stop mutating the shared service-domain index during domain inference
- filter candidate domains into a per-request immutable list
- prevent concurrent browser bootstrap requests from causing `ConcurrentModificationException`
- add a regression test proving domain inference leaves the shared index unchanged

## Verification
- installed the changed `reflex-platform` locally
- explicitly compiled `reflex-platform-test`
- ran the full `reflex-platform-test` suite successfully