### PR TITLE
Add RX module reflection and stable workbench identities

### DIFF
--- a/explorer-rx-module/src/hiconic/rx/explorer/processing/platformreflection/application/StandardRxAppInfoProvider.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/processing/platformreflection/application/StandardRxAppInfoProvider.java
@@ -16,9 +16,11 @@ import com.braintribe.utils.stream.pools.CompoundBlockPool;
 import com.braintribe.utils.stream.stats.BlockKind;
 import com.braintribe.utils.stream.stats.StreamPipeBlockStats;
 
+import hiconic.rx.module.api.wire.PlatformReflectionContract;
 import hiconic.rx.module.api.wire.RxApplicationContract;
 import hiconic.rx.module.api.wire.RxApplicationFilesContract;
 import hiconic.rx.reflection.model.application.RxAppInfo;
+import hiconic.rx.reflection.model.module.RxModuleInfo;
 import hiconic.rx.reflection.model.streampipes.PoolKind;
 import hiconic.rx.reflection.model.streampipes.StreamPipeBlocksInfo;
 import hiconic.rx.reflection.model.streampipes.StreamPipesInfo;
@@ -31,6 +33,7 @@ public class StandardRxAppInfoProvider implements Supplier<RxAppInfo> {
 
 	private RxApplicationContract application;
 	private RxApplicationFilesContract applicationFiles;
+	private PlatformReflectionContract platformReflection;
 
 	private CompoundBlockPool compoundBlockPool;
 
@@ -44,6 +47,11 @@ public class StandardRxAppInfoProvider implements Supplier<RxAppInfo> {
 		this.applicationFiles = applicationFiles;
 	}
 
+	@Required
+	public void setPlatformReflectionContract(PlatformReflectionContract platformReflection) {
+		this.platformReflection = platformReflection;
+	}
+
 	@Configurable
 	public void setCompoundBlockPool(CompoundBlockPool compoundBlockPool) {
 		this.compoundBlockPool = compoundBlockPool;
@@ -54,6 +62,13 @@ public class StandardRxAppInfoProvider implements Supplier<RxAppInfo> {
 		RxAppInfo result = RxAppInfo.T.create();
 		result.setApplicationName(application.applicationName());
 		result.setApplicationId(application.applicationId());
+		result.setModuleInfos(platformReflection.modules().stream().map(module -> {
+			RxModuleInfo info = RxModuleInfo.T.create();
+			info.setGroupId(module.groupId());
+			info.setArtifactId(module.artifactId());
+			info.setVersion(module.version());
+			return info;
+		}).toList());
 		result.setStreamPipeInfo(prepareStreamPipeBlocksInfo());
 		result.setTempDirInfo(createFolderInfo(applicationFiles.tmpPath()));
 

--- a/explorer-rx-module/src/hiconic/rx/explorer/wire/space/PlatformReflectionSpace.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/wire/space/PlatformReflectionSpace.java
@@ -91,6 +91,7 @@ public class PlatformReflectionSpace implements WireSpace {
 		StandardRxAppInfoProvider bean = new StandardRxAppInfoProvider();
 		bean.setPlatformApplicationContract(platform.application());
 		bean.setApplicationFilesContract(platformResources);
+		bean.setPlatformReflectionContract(platform.reflection());
 		if (transientData.streamPipeFactory() instanceof CompoundBlockPool blockPool)
 			bean.setCompoundBlockPool(blockPool);
 		return bean;

--- a/reflex-module-api/pom.xml
+++ b/reflex-module-api/pom.xml
@@ -30,6 +30,11 @@ limitations under the License.
     </licenses>
     <dependencies>
         <dependency>
+            <groupId>com.braintribe.common</groupId>
+            <artifactId>common-api</artifactId>
+            <version>${V.com.braintribe.common}</version>
+        </dependency>
+        <dependency>
             <groupId>com.braintribe.gm</groupId>
             <artifactId>service-api-commons</artifactId>
             <version>${V.com.braintribe.gm}</version>

--- a/reflex-module-api/src/hiconic/rx/module/api/wire/ModuleReflectionContract.java
+++ b/reflex-module-api/src/hiconic/rx/module/api/wire/ModuleReflectionContract.java
@@ -1,0 +1,41 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0
+// ============================================================================
+package hiconic.rx.module.api.wire;
+
+import com.braintribe.common.artifact.ArtifactReflection;
+import com.braintribe.wire.api.space.WireSpace;
+
+/**
+ * Reflection of the RX module owning the current module Wire context.
+ * <p>
+ * The platform binds a dedicated instance for every loaded module. Importing this contract from a module therefore always reflects that module,
+ * analogous to the classic Tribefire module reflection contract.
+ */
+public interface ModuleReflectionContract extends WireSpace {
+
+	ArtifactReflection artifactReflection();
+
+	ClassLoader moduleClassLoader();
+
+	default String artifactId() {
+		return artifactReflection().artifactId();
+	}
+
+	default String groupId() {
+		return artifactReflection().groupId();
+	}
+
+	default String version() {
+		return artifactReflection().version();
+	}
+
+	default String moduleName() {
+		return artifactReflection().name();
+	}
+
+	default String globalId() {
+		return "module://" + moduleName();
+	}
+
+}

--- a/reflex-module-api/src/hiconic/rx/module/api/wire/PlatformReflectionContract.java
+++ b/reflex-module-api/src/hiconic/rx/module/api/wire/PlatformReflectionContract.java
@@ -1,0 +1,15 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0
+// ============================================================================
+package hiconic.rx.module.api.wire;
+
+import java.util.List;
+
+import com.braintribe.wire.api.space.WireSpace;
+
+/** Platform-wide reflection of the RX modules loaded so far. */
+public interface PlatformReflectionContract extends WireSpace {
+
+	List<ModuleReflectionContract> modules();
+
+}

--- a/reflex-module-api/src/hiconic/rx/module/api/wire/RxPlatformContract.java
+++ b/reflex-module-api/src/hiconic/rx/module/api/wire/RxPlatformContract.java
@@ -44,6 +44,8 @@ public interface RxPlatformContract extends DeprecatedRxPlatformContract {
 
 	RxProcessLaunchContract processLaunch();
 
+	PlatformReflectionContract reflection();
+
 	RxServiceProcessingContract serviceProcessing();
 
 	RxTransientDataContract transientData();

--- a/reflex-platform-test/src/hiconic/rx/platform/loading/RxModuleLoadingTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/loading/RxModuleLoadingTest.java
@@ -15,10 +15,14 @@ package hiconic.rx.platform.loading;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.Test;
 
 import com.braintribe.wire.api.Wire;
 import com.braintribe.wire.api.context.WireContext;
+import com.braintribe.common.artifact.ArtifactReflection;
 
 import hiconic.rx.module.api.wire.RxModuleContract;
 import hiconic.rx.platform.loading.samples.api.ApiContract;
@@ -40,6 +44,28 @@ public class RxModuleLoadingTest {
 		RxModuleContract exporterSpace = (RxModuleContract) wireContext.contract();
 		assertThat(exporterSpace).isNotNull();
 		assertThat(exporterSpace.getClass().getName()).isEqualTo(ExporterSpace.class.getName());
+	}
+
+	@Test
+	public void resolvesOwningArtifactReflectionFromExplodedTestArtifact() {
+		ArtifactReflection reflection = ModuleArtifactReflectionResolver.resolve(ExportingModule.INSTANCE);
+
+		assertThat(reflection.groupId()).isEqualTo("hiconic.platform.reflex");
+		assertThat(reflection.artifactId()).isEqualTo("reflex-platform-test");
+	}
+
+	@Test
+	public void resolvesLegacyModuleCoordinatesFromPackagedSolutions() throws Exception {
+		Path application = Files.createTempDirectory("rx-module-reflection-test");
+		Path lib = Files.createDirectory(application.resolve("lib"));
+		Path jar = Files.createFile(lib.resolve("some-rx-module-1.2.3-rc.jar"));
+		Files.writeString(application.resolve("packaged-solutions.txt"), "example.group:some-rx-module#1.2.3-rc\n");
+
+		ArtifactReflection reflection = ModuleArtifactReflectionResolver.reflectionFromLegacyJarName(jar);
+
+		assertThat(reflection.groupId()).isEqualTo("example.group");
+		assertThat(reflection.artifactId()).isEqualTo("some-rx-module");
+		assertThat(reflection.version()).isEqualTo("1.2.3-rc");
 	}
 
 }

--- a/reflex-platform/src/hiconic/rx/platform/loading/ModuleArtifactReflectionResolver.java
+++ b/reflex-platform/src/hiconic/rx/platform/loading/ModuleArtifactReflectionResolver.java
@@ -1,0 +1,306 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0
+// ============================================================================
+package hiconic.rx.platform.loading;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import com.braintribe.common.artifact.ArtifactReflection;
+
+import hiconic.rx.module.api.wire.RxModule;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/** Resolves the generated artifact reflection owning an RX module without requiring module-specific declarations. */
+final class ModuleArtifactReflectionResolver {
+
+	private static final String DESCRIPTOR_PATH = "META-INF/artifact-descriptor.properties";
+
+	static ArtifactReflection resolve(RxModule<?> module) {
+		Class<?> moduleClass = module.getClass();
+		URL location = codeSourceLocation(moduleClass);
+
+		List<DescriptorSource> candidates = descriptorCandidates(location);
+		List<ArtifactReflection> reflections = new ArrayList<>();
+		List<String> failures = new ArrayList<>();
+
+		for (DescriptorSource candidate : candidates) {
+			try {
+				ArtifactReflection reflection = loadReflection(candidate, moduleClass.getClassLoader());
+				if (reflection != null)
+					reflections.add(reflection);
+			} catch (Exception e) {
+				failures.add(candidate.description() + ": " + e.getMessage());
+			}
+		}
+
+		if (reflections.size() == 1)
+			return reflections.get(0);
+
+		if (reflections.isEmpty()) {
+			ArtifactReflection pomReflection = reflectionFromPomNearLocation(location);
+			if (pomReflection != null)
+				return pomReflection;
+
+			ArtifactReflection legacyReflection = reflectionFromLegacyJarName(location);
+			if (legacyReflection != null)
+				return legacyReflection;
+
+			throw new IllegalStateException("Cannot resolve artifact reflection for RX module " + moduleClass.getName() + " loaded from " + location
+					+ ". Checked: " + candidates.stream().map(DescriptorSource::description).toList()
+					+ (failures.isEmpty() ? "" : ". Invalid descriptors: " + failures));
+		}
+
+		throw new IllegalStateException("Ambiguous artifact reflection for RX module " + moduleClass.getName() + " loaded from " + location + ": "
+				+ reflections.stream().map(ArtifactReflection::versionedName).toList());
+	}
+
+	private static URL codeSourceLocation(Class<?> moduleClass) {
+		if (moduleClass.getProtectionDomain() == null || moduleClass.getProtectionDomain().getCodeSource() == null
+				|| moduleClass.getProtectionDomain().getCodeSource().getLocation() == null)
+			throw new IllegalStateException("RX module class has no code source: " + moduleClass.getName());
+
+		return moduleClass.getProtectionDomain().getCodeSource().getLocation();
+	}
+
+	private static List<DescriptorSource> descriptorCandidates(URL location) {
+		if (!"file".equalsIgnoreCase(location.getProtocol()))
+			throw new IllegalStateException("Unsupported RX module code source URL: " + location);
+
+		Path path;
+		try {
+			path = Path.of(new URI(location.toExternalForm())).toAbsolutePath().normalize();
+		} catch (URISyntaxException e) {
+			throw new IllegalStateException("Invalid RX module code source URL: " + location, e);
+		}
+
+		if (Files.isRegularFile(path))
+			return List.of(DescriptorSource.jar(path));
+
+		Set<Path> paths = new LinkedHashSet<>();
+		paths.add(path.resolve(DESCRIPTOR_PATH));
+
+		Path artifactRoot = findArtifactRoot(path);
+		if (artifactRoot != null) {
+			paths.add(artifactRoot.resolve("class-gen").resolve(DESCRIPTOR_PATH));
+			paths.add(artifactRoot.resolve("build").resolve(DESCRIPTOR_PATH));
+			paths.add(artifactRoot.resolve("target/classes").resolve(DESCRIPTOR_PATH));
+		}
+
+		return paths.stream().filter(Files::isRegularFile).map(DescriptorSource::file).toList();
+	}
+
+	private static Path findArtifactRoot(Path start) {
+		for (Path current = start; current != null; current = current.getParent())
+			if (Files.isRegularFile(current.resolve("pom.xml")))
+				return current;
+
+		return null;
+	}
+
+	private static ArtifactReflection reflectionFromPomNearLocation(URL location) {
+		if (!"file".equalsIgnoreCase(location.getProtocol()))
+			return null;
+
+		try {
+			Path codeSource = Path.of(location.toURI()).toAbsolutePath().normalize();
+			Path pom;
+			if (Files.isDirectory(codeSource)) {
+				Path artifactRoot = findArtifactRoot(codeSource);
+				pom = artifactRoot == null ? null : artifactRoot.resolve("pom.xml");
+			} else {
+				String fileName = codeSource.getFileName().toString();
+				pom = fileName.endsWith(".jar") ? codeSource.resolveSibling(fileName.substring(0, fileName.length() - 4) + ".pom") : null;
+			}
+			if (pom == null || !Files.isRegularFile(pom))
+				return null;
+
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+			Element project = factory.newDocumentBuilder().parse(pom.toFile()).getDocumentElement();
+			Element parent = directChild(project, "parent");
+			String groupId = firstNonBlank(directText(project, "groupId"), directText(parent, "groupId"));
+			String artifactId = directText(project, "artifactId");
+			String version = firstNonBlank(directText(project, "version"), directText(parent, "version"));
+			if (groupId == null || artifactId == null || version == null)
+				throw new IllegalStateException("Incomplete artifact coordinates in " + pom);
+
+			return new SimpleArtifactReflection(groupId, artifactId, version);
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot derive artifact reflection from POM near RX module location " + location, e);
+		}
+	}
+
+	/** Compatibility for already published RX modules predating generated artifact descriptors. */
+	private static ArtifactReflection reflectionFromLegacyJarName(URL location) {
+		if (!"file".equalsIgnoreCase(location.getProtocol()))
+			return null;
+
+		try {
+			return reflectionFromLegacyJarName(Path.of(location.toURI()).toAbsolutePath().normalize());
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot derive legacy artifact reflection from RX module location " + location, e);
+		}
+	}
+
+	static ArtifactReflection reflectionFromLegacyJarName(Path path) {
+		try {
+			if (!Files.isRegularFile(path))
+				return null;
+
+			String fileName = path.getFileName().toString();
+			if (!fileName.endsWith(".jar"))
+				return null;
+
+			String stem = fileName.substring(0, fileName.length() - 4);
+			for (int separator = stem.indexOf('-'); separator >= 0; separator = stem.indexOf('-', separator + 1)) {
+				String version = stem.substring(separator + 1);
+				if (version.matches("\\d+\\.\\d+\\.\\d+(?:[-.][A-Za-z0-9_.-]+)?")) {
+					String artifactId = stem.substring(0, separator);
+					String groupId = groupIdFromPackagedSolutions(path, artifactId, version);
+					return new SimpleArtifactReflection(groupId == null ? "legacy.unresolved" : groupId, artifactId, version);
+				}
+			}
+			return null;
+		} catch (Exception e) {
+			throw new IllegalStateException("Cannot derive legacy artifact reflection from RX module location " + path, e);
+		}
+	}
+
+	private static String groupIdFromPackagedSolutions(Path jar, String artifactId, String version) throws IOException {
+		Path lib = jar.getParent();
+		Path application = lib == null ? null : lib.getParent();
+		Path solutions = application == null ? null : application.resolve("packaged-solutions.txt");
+		if (solutions == null || !Files.isRegularFile(solutions))
+			return null;
+
+		String suffix = ":" + artifactId + "#" + version;
+		List<String> matches = Files.readAllLines(solutions).stream().filter(line -> line.endsWith(suffix)).toList();
+		if (matches.size() > 1)
+			throw new IllegalStateException("Ambiguous artifact coordinates for " + jar + " in " + solutions + ": " + matches);
+		return matches.isEmpty() ? null : matches.get(0).substring(0, matches.get(0).length() - suffix.length());
+	}
+
+	private static Element directChild(Element parent, String name) {
+		if (parent == null)
+			return null;
+		for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling())
+			if (child instanceof Element element && name.equals(element.getLocalName() == null ? element.getNodeName() : element.getLocalName()))
+				return element;
+		return null;
+	}
+
+	private static String directText(Element parent, String name) {
+		Element child = directChild(parent, name);
+		if (child == null)
+			return null;
+		String value = child.getTextContent();
+		return value == null || value.isBlank() ? null : value.trim();
+	}
+
+	private static String firstNonBlank(String first, String second) {
+		return first != null ? first : second;
+	}
+
+	private record SimpleArtifactReflection(String groupId, String artifactId, String version) implements ArtifactReflection {
+		@Override public Set<String> archetypes() { return Set.of(); }
+		@Override public String name() { return groupId + ":" + artifactId; }
+		@Override public String versionedName() { return name() + "#" + version; }
+	}
+
+	private static ArtifactReflection loadReflection(DescriptorSource source, ClassLoader classLoader) throws Exception {
+		Properties properties = new Properties();
+		try (InputStream in = source.open()) {
+			if (in == null)
+				return null;
+			properties.load(in);
+		}
+
+		String reflectionClassName = required(properties, "reflection-class", source);
+		Class<?> reflectionClass = Class.forName(reflectionClassName, true, classLoader);
+		Field reflectionField = reflectionClass.getField("reflection");
+		Object value = reflectionField.get(null);
+		if (!(value instanceof ArtifactReflection reflection))
+			throw new IllegalStateException("Field 'reflection' of " + reflectionClassName + " is not an ArtifactReflection");
+
+		verify(properties, "groupId", reflection.groupId(), source);
+		verify(properties, "artifactId", reflection.artifactId(), source);
+		verify(properties, "version", reflection.version(), source);
+		return reflection;
+	}
+
+	private static String required(Properties properties, String name, DescriptorSource source) {
+		String value = properties.getProperty(name);
+		if (value == null || value.isBlank())
+			throw new IllegalStateException("Missing property '" + name + "' in " + source.description());
+		return value;
+	}
+
+	private static void verify(Properties properties, String name, String actual, DescriptorSource source) {
+		String expected = required(properties, name, source);
+		if (!expected.equals(actual))
+			throw new IllegalStateException("Artifact reflection property '" + name + "' is '" + actual + "' but descriptor " + source.description()
+					+ " declares '" + expected + "'");
+	}
+
+	private interface DescriptorSource {
+		InputStream open() throws IOException;
+		String description();
+
+		static DescriptorSource file(Path descriptor) {
+			return new DescriptorSource() {
+				@Override public InputStream open() throws IOException { return Files.newInputStream(descriptor); }
+				@Override public String description() { return descriptor.toString(); }
+			};
+		}
+
+		static DescriptorSource jar(Path jar) {
+			return new DescriptorSource() {
+				private JarFile openedJar;
+
+				@Override
+				public InputStream open() throws IOException {
+					openedJar = new JarFile(jar.toFile());
+					JarEntry entry = openedJar.getJarEntry(DESCRIPTOR_PATH);
+					if (entry == null) {
+						openedJar.close();
+						openedJar = null;
+						return null;
+					}
+					InputStream input = openedJar.getInputStream(entry);
+					return new InputStream() {
+						@Override public int read() throws IOException { return input.read(); }
+						@Override public int read(byte[] b, int off, int len) throws IOException { return input.read(b, off, len); }
+						@Override public void close() throws IOException { try { input.close(); } finally { openedJar.close(); } }
+					};
+				}
+
+				@Override public String description() { return jar + "!/" + DESCRIPTOR_PATH; }
+			};
+		}
+	}
+
+}

--- a/reflex-platform/src/hiconic/rx/platform/loading/ModuleReflectionSpace.java
+++ b/reflex-platform/src/hiconic/rx/platform/loading/ModuleReflectionSpace.java
@@ -1,0 +1,30 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0
+// ============================================================================
+package hiconic.rx.platform.loading;
+
+import com.braintribe.common.artifact.ArtifactReflection;
+
+import hiconic.rx.module.api.wire.ModuleReflectionContract;
+
+final class ModuleReflectionSpace implements ModuleReflectionContract {
+
+	private final ArtifactReflection artifactReflection;
+	private final ClassLoader moduleClassLoader;
+
+	ModuleReflectionSpace(ArtifactReflection artifactReflection, ClassLoader moduleClassLoader) {
+		this.artifactReflection = artifactReflection;
+		this.moduleClassLoader = moduleClassLoader;
+	}
+
+	@Override
+	public ArtifactReflection artifactReflection() {
+		return artifactReflection;
+	}
+
+	@Override
+	public ClassLoader moduleClassLoader() {
+		return moduleClassLoader;
+	}
+
+}

--- a/reflex-platform/src/hiconic/rx/platform/loading/RxModuleLoader.java
+++ b/reflex-platform/src/hiconic/rx/platform/loading/RxModuleLoader.java
@@ -49,6 +49,8 @@ import com.braintribe.wire.api.space.WireSpace;
 import com.braintribe.wire.impl.properties.PropertyLookups;
 
 import hiconic.rx.module.api.wire.EnvironmentPropertiesContract;
+import hiconic.rx.module.api.wire.ModuleReflectionContract;
+import hiconic.rx.module.api.wire.PlatformReflectionContract;
 import hiconic.rx.module.api.wire.RxContractSpaceResolverConfigurator;
 import hiconic.rx.module.api.wire.RxModule;
 import hiconic.rx.module.api.wire.RxModuleContract;
@@ -57,13 +59,13 @@ import hiconic.rx.module.api.wire.SystemPropertiesContract;
 import hiconic.rx.platform.conf.RxPropertyResolver;
 import hiconic.rx.platform.loading.RxModuleAnalysis.RxExportEntry;
 
-public class RxModuleLoader implements LifecycleAware {
+public class RxModuleLoader implements LifecycleAware, PlatformReflectionContract {
 
 	private static final Logger logger = Logger.getLogger(RxModuleLoader.class);
 
 	private WireContext<?> parentContext;
 	
-	record LoadedModule(WireContext<RxModuleContract> wireContext, WireModule module) {}
+	record LoadedModule(WireContext<RxModuleContract> wireContext, WireModule module, ModuleReflectionContract reflection) {}
 	
 	private List<LoadedModule> loadedModules;
 	private RxContractSpaceResolverConfigurator resolverConfigurator;
@@ -97,6 +99,11 @@ public class RxModuleLoader implements LifecycleAware {
 		return loadedModules.stream() //
 				.map(c -> c.wireContext().contract()) //
 				.toList();
+	}
+
+	@Override
+	public List<ModuleReflectionContract> modules() {
+		return loadedModules == null ? List.of() : loadedModules.stream().map(LoadedModule::reflection).toList();
 	}
 
 	@Override
@@ -148,12 +155,12 @@ public class RxModuleLoader implements LifecycleAware {
 
 		// TODO parallelize instead
 		for (RxModuleNode node : nodesSortedDependenciesFirst(analysis)) {
-			var maybeWireCtx = loadWireContextForModule(node);
+			var maybeLoadedModule = loadWireContextForModule(node);
 
-			if (maybeWireCtx.isUnsatisfied())
-				lazyError.get().getReasons().add(maybeWireCtx.whyUnsatisfied());
+			if (maybeLoadedModule.isUnsatisfied())
+				lazyError.get().getReasons().add(maybeLoadedModule.whyUnsatisfied());
 			else
-				contexts.add(new LoadedModule(maybeWireCtx.get(), node.module));
+				contexts.add(maybeLoadedModule.get());
 		}
 
 		if (lazyError.isInitialized())
@@ -168,13 +175,16 @@ public class RxModuleLoader implements LifecycleAware {
 		return rxNodes;
 	}
 
-	private Maybe<WireContext<RxModuleContract>> loadWireContextForModule(RxModuleNode node) {
+	private Maybe<LoadedModule> loadWireContextForModule(RxModuleNode node) {
 		var rxModule = node.module;
 
 		printWireModule(rxModule.moduleName());
 
 		try {
+			var artifactReflection = ModuleArtifactReflectionResolver.resolve(rxModule);
+			var moduleReflection = new ModuleReflectionSpace(artifactReflection, rxModule.getClass().getClassLoader());
 			WireContextBuilder<RxModuleContract> contextBuilder = Wire.contextBuilder(rxModule);
+			contextBuilder.bindContract(ModuleReflectionContract.class, moduleReflection);
 			for (RxExportEntry export : node.exports)
 				if (export.spaceClass != null)
 					contextBuilder.bindContract(export.contractClass, export.spaceClass);
@@ -187,7 +197,7 @@ public class RxModuleLoader implements LifecycleAware {
 			for (RxExportEntry export : node.exports)
 				export.moduleWireContext = wireContext;
 
-			return Maybe.complete(wireContext);
+			return Maybe.complete(new LoadedModule(wireContext, node.module, moduleReflection));
 
 		} catch (Exception e) {
 			String tracebackId = UUID.randomUUID().toString();

--- a/reflex-platform/src/hiconic/rx/platform/wire/space/RxPlatformSpace.java
+++ b/reflex-platform/src/hiconic/rx/platform/wire/space/RxPlatformSpace.java
@@ -39,6 +39,7 @@ import hiconic.rx.module.api.wire.RxMarshallingContract;
 import hiconic.rx.module.api.wire.RxModuleContract;
 import hiconic.rx.module.api.wire.RxPackagedResourcesContract;
 import hiconic.rx.module.api.wire.RxPackagedPublicResourcesContract;
+import hiconic.rx.module.api.wire.PlatformReflectionContract;
 import hiconic.rx.module.api.wire.RxProcessLaunchContract;
 import hiconic.rx.module.api.wire.RxServiceProcessingContract;
 import hiconic.rx.module.api.wire.RxTransientDataContract;
@@ -80,6 +81,7 @@ public class RxPlatformSpace extends CoreServicesSpace implements ExtendedRxPlat
 	@Override public RxPackagedResourcesContract packagedResources() { return packagedResources; }
 	@Override public RxPackagedPublicResourcesContract packagedPublicResources() { return packagedPublicResources; }
 	@Override public RxProcessLaunchContract processLaunch() { return this; }
+	@Override public PlatformReflectionContract reflection() { return moduleLoader(); }
 	@Override public RxServiceProcessingContract serviceProcessing() { return serviceProcessing; }
 	@Override public RxTransientDataContract transientData() { return transientData; }
 	// @formatter:on

--- a/web-api-mapping-meta-data-model/src/META-INF/gmf.mda
+++ b/web-api-mapping-meta-data-model/src/META-INF/gmf.mda
@@ -7,7 +7,7 @@ hiconic.rx.webapi.model.annotation.ResponseMimeType,hiconic.rx.webapi.model.meta
 hiconic.rx.webapi.model.annotation.ResponseDepth,hiconic.rx.webapi.model.meta.ResponseDepth,value,depth
 hiconic.rx.webapi.model.annotation.ResponseEntityRecurrenceDepth,hiconic.rx.webapi.model.meta.ResponseEntityRecurrenceDepth,value,depth
 hiconic.rx.webapi.model.annotation.ResponseTypeExplicitness,hiconic.rx.webapi.model.meta.ResponseTypeExplicitness,value,typeExplicitness
-hiconic.rx.webapi.model.annotation.RequestDecodingLenience,hiconic.rx.webapi.model.meta.RequestDecodingLenience,value,active
+hiconic.rx.webapi.model.annotation.RequestDecodingLenience,hiconic.rx.webapi.model.meta.RequestDecodingLenience
 hiconic.rx.webapi.model.annotation.ResponseAsResourcePayload,hiconic.rx.webapi.model.meta.ResponseAsResourcePayload
 hiconic.rx.webapi.model.annotation.ResponseWithDownloadDialog,hiconic.rx.webapi.model.meta.ResponseWithDownloadDialog
 hiconic.rx.webapi.model.annotation.RequestMapping,hiconic.rx.webapi.model.meta.RequestMapping,inherited,inherited,path,path,method,method,section,section,responseProjection,responseProjection,responseAsResourcePayload,responseAsResourcePayload,responseWithDownloadDialog,responseWithDownloadDialog,responseMimeType,responseMimeType,hideSerializedRequest,hideSerializedRequest,announceAsMultipart,announceAsMultipart,useSessionEvaluation,useSessionEvaluation,entityRecurrenceDepth,entityRecurrenceDepth,depth,depth,decodingLenience,decodingLenience

--- a/web-api-mapping-meta-data-model/src/hiconic/rx/webapi/model/annotation/RequestDecodingLenience.java
+++ b/web-api-mapping-meta-data-model/src/hiconic/rx/webapi/model/annotation/RequestDecodingLenience.java
@@ -19,11 +19,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Annotation for {@link hiconic.rx.webapi.model.meta.RequestDecodingLenience}. */
+/**
+ * Enables tolerant decoding of unknown request properties.
+ * <p>
+ * The corresponding metadata is an explicit predicate: the annotation's presence enables it. A mapping-specific override can be expressed with
+ * {@link hiconic.rx.webapi.model.meta.RequestMapping#getDecodingLenience()}.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
 public @interface RequestDecodingLenience {
 	String globalId() default "";
-	boolean value() default true;
 }

--- a/workbench-module-api/src/hiconic/rx/workbench/api/WorkbenchContract.java
+++ b/workbench-module-api/src/hiconic/rx/workbench/api/WorkbenchContract.java
@@ -13,4 +13,9 @@ public interface WorkbenchContract extends RxExportContract {
 	 */
 	void registerInitializer(String workbenchAccessId, WorkbenchInitializer initializer);
 
+	/** Registers an initializer with a stable Wire-derived identity for all entities it creates. */
+	default void registerInitializer(String workbenchAccessId, WorkbenchInitializerRegistration registration) {
+		registerInitializer(workbenchAccessId, registration.initializer());
+	}
+
 }

--- a/workbench-module-api/src/hiconic/rx/workbench/api/WorkbenchInitializerIdentity.java
+++ b/workbench-module-api/src/hiconic/rx/workbench/api/WorkbenchInitializerIdentity.java
@@ -1,0 +1,52 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0
+// ============================================================================
+package hiconic.rx.workbench.api;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.braintribe.wire.api.scope.InstanceQualification;
+
+import hiconic.rx.module.api.wire.ModuleReflectionContract;
+
+/** Stable, URL-friendly identity of a Wire-managed workbench initializer. */
+public final class WorkbenchInitializerIdentity {
+
+	private static final Pattern ARTIFACT_ID = Pattern.compile("[A-Za-z0-9_.-]+");
+	private static final Pattern WIRE_NAME = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+	private final String prefix;
+
+	private WorkbenchInitializerIdentity(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public static WorkbenchInitializerIdentity wire(ModuleReflectionContract module, InstanceQualification qualification) {
+		Objects.requireNonNull(module, "module");
+		Objects.requireNonNull(qualification, "qualification");
+
+		String artifactId = requireArtifactId(module.artifactId());
+		String spaceName = requireWireName("Wire space", qualification.space().getClass().getSimpleName());
+		String beanName = requireWireName("Wire bean", qualification.name());
+		return new WorkbenchInitializerIdentity(artifactId + "--" + spaceName + "." + beanName);
+	}
+
+	public String prefix() {
+		return prefix;
+	}
+
+	private static String requireArtifactId(String value) {
+		if (value == null || !ARTIFACT_ID.matcher(value).matches() || value.contains("--"))
+			throw new IllegalArgumentException("Artifact id used for a workbench identity must match " + ARTIFACT_ID + " and not contain '--': "
+					+ value);
+		return value;
+	}
+
+	private static String requireWireName(String kind, String value) {
+		if (value == null || !WIRE_NAME.matcher(value).matches())
+			throw new IllegalArgumentException(kind + " used for a workbench identity must match " + WIRE_NAME + ": " + value);
+		return value;
+	}
+
+}

--- a/workbench-module-api/src/hiconic/rx/workbench/api/WorkbenchInitializerRegistration.java
+++ b/workbench-module-api/src/hiconic/rx/workbench/api/WorkbenchInitializerRegistration.java
@@ -1,0 +1,16 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0
+// ============================================================================
+package hiconic.rx.workbench.api;
+
+import java.util.Objects;
+
+/** A workbench initializer together with the stable identity of its managed Wire bean. */
+public record WorkbenchInitializerRegistration(WorkbenchInitializer initializer, WorkbenchInitializerIdentity identity) {
+
+	public WorkbenchInitializerRegistration {
+		Objects.requireNonNull(initializer, "initializer");
+		Objects.requireNonNull(identity, "identity");
+	}
+
+}

--- a/workbench-rx-module/src/hiconic/rx/workbench/module/wire/space/WorkbenchRxModuleSpace.java
+++ b/workbench-rx-module/src/hiconic/rx/workbench/module/wire/space/WorkbenchRxModuleSpace.java
@@ -5,11 +5,15 @@ package hiconic.rx.workbench.module.wire.space;
 
 import com.braintribe.wire.api.annotation.Import;
 import com.braintribe.wire.api.annotation.Managed;
+import com.braintribe.wire.api.scope.InstanceConfiguration;
 
 import hiconic.rx.access.module.api.AccessContract;
+import hiconic.rx.module.api.wire.ModuleReflectionContract;
 import hiconic.rx.module.api.wire.RxModuleContract;
 import hiconic.rx.workbench.api.WorkbenchContract;
 import hiconic.rx.workbench.api.WorkbenchInitializer;
+import hiconic.rx.workbench.api.WorkbenchInitializerIdentity;
+import hiconic.rx.workbench.api.WorkbenchInitializerRegistration;
 import hiconic.rx.workbench.processing.WorkbenchInitializers;
 
 @Managed
@@ -17,10 +21,17 @@ public class WorkbenchRxModuleSpace implements RxModuleContract, WorkbenchContra
 
 	@Import
 	private AccessContract access;
+	@Import
+	private ModuleReflectionContract moduleReflection;
 
 	@Override
 	public void registerInitializer(String workbenchAccessId, WorkbenchInitializer initializer) {
 		initializers().register(workbenchAccessId, initializer);
+	}
+
+	@Override
+	public void registerInitializer(String workbenchAccessId, WorkbenchInitializerRegistration registration) {
+		initializers().register(workbenchAccessId, registration);
 	}
 
 	@Override
@@ -32,6 +43,7 @@ public class WorkbenchRxModuleSpace implements RxModuleContract, WorkbenchContra
 	private WorkbenchInitializers initializers() {
 		WorkbenchInitializers bean = new WorkbenchInitializers();
 		bean.setSessionFactory(access.systemSessionFactory());
+		bean.setStandardInitializerIdentity(WorkbenchInitializerIdentity.wire(moduleReflection, InstanceConfiguration.currentInstance().qualification()));
 		return bean;
 	}
 

--- a/workbench-rx-module/src/hiconic/rx/workbench/processing/WorkbenchInitializers.java
+++ b/workbench-rx-module/src/hiconic/rx/workbench/processing/WorkbenchInitializers.java
@@ -11,6 +11,11 @@ import java.util.Map;
 
 import com.braintribe.cfg.Required;
 import com.braintribe.model.folder.Folder;
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.manipulation.InstantiationManipulation;
+import com.braintribe.model.generic.manipulation.Manipulation;
+import com.braintribe.model.generic.manipulation.ManipulationType;
+import com.braintribe.model.generic.tracking.ManipulationListener;
 import com.braintribe.model.processing.query.fluent.EntityQueryBuilder;
 import com.braintribe.model.processing.session.api.persistence.PersistenceGmSession;
 import com.braintribe.model.processing.session.api.persistence.PersistenceGmSessionFactory;
@@ -19,35 +24,100 @@ import com.braintribe.model.workbench.WorkbenchConfiguration;
 import com.braintribe.model.workbench.WorkbenchPerspective;
 
 import hiconic.rx.workbench.api.WorkbenchInitializer;
+import hiconic.rx.workbench.api.WorkbenchInitializerIdentity;
+import hiconic.rx.workbench.api.WorkbenchInitializerRegistration;
 
 public class WorkbenchInitializers {
 
-	private final Map<String, List<WorkbenchInitializer>> initializers = new LinkedHashMap<>();
+	private record RegisteredInitializer(WorkbenchInitializer initializer, WorkbenchInitializerIdentity identity) {}
+
+	private final Map<String, List<RegisteredInitializer>> initializers = new LinkedHashMap<>();
 	private PersistenceGmSessionFactory sessionFactory;
+	private WorkbenchInitializerIdentity standardInitializerIdentity;
 
 	@Required
 	public void setSessionFactory(PersistenceGmSessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
 
+	@Required
+	public void setStandardInitializerIdentity(WorkbenchInitializerIdentity standardInitializerIdentity) {
+		this.standardInitializerIdentity = standardInitializerIdentity;
+	}
+
 	public synchronized void register(String accessId, WorkbenchInitializer initializer) {
-		initializers.computeIfAbsent(accessId, ignored -> new ArrayList<>()).add(initializer);
+		initializers.computeIfAbsent(accessId, ignored -> new ArrayList<>()).add(new RegisteredInitializer(initializer, null));
+	}
+
+	public synchronized void register(String accessId, WorkbenchInitializerRegistration registration) {
+		List<RegisteredInitializer> accessInitializers = initializers.computeIfAbsent(accessId, ignored -> new ArrayList<>());
+		String prefix = registration.identity().prefix();
+		if (standardInitializerIdentity.prefix().equals(prefix)
+				|| accessInitializers.stream().map(RegisteredInitializer::identity).filter(identity -> identity != null)
+						.anyMatch(identity -> identity.prefix().equals(prefix)))
+			throw new IllegalStateException("Duplicate stable workbench initializer identity for access '" + accessId + "': " + prefix);
+
+		accessInitializers.add(new RegisteredInitializer(registration.initializer(), registration.identity()));
 	}
 
 	public void initializeAll() {
-		Map<String, List<WorkbenchInitializer>> snapshot;
+		Map<String, List<RegisteredInitializer>> snapshot;
 		synchronized (this) {
 			snapshot = new LinkedHashMap<>(initializers);
 		}
 
-		for (Map.Entry<String, List<WorkbenchInitializer>> entry : snapshot.entrySet()) {
+		for (Map.Entry<String, List<RegisteredInitializer>> entry : snapshot.entrySet()) {
 			PersistenceGmSession session = sessionFactory.newSession(entry.getKey());
-			ensureStandardWorkbench(session);
+			initializeWithStableIds(session, standardInitializerIdentity, () -> ensureStandardWorkbench(session));
 			// The standard stage is a predecessor of all contributed initializers. Commit it so their
 			// access queries can resolve the entities just established by that stage.
 			session.commit();
-			entry.getValue().forEach(initializer -> initializer.initialize(session));
+			entry.getValue().forEach(initializer -> initializeWithStableIds(session, initializer.identity(), () -> initializer.initializer().initialize(session)));
 			session.commit();
+		}
+	}
+
+	private void initializeWithStableIds(PersistenceGmSession session, WorkbenchInitializerIdentity identity, Runnable initializer) {
+		if (identity == null) {
+			initializer.run();
+			return;
+		}
+
+		StableIdAssigner assigner = new StableIdAssigner(identity.prefix());
+		session.listeners().add(assigner);
+		try {
+			initializer.run();
+			assigner.assign();
+		} finally {
+			session.listeners().remove(assigner);
+		}
+	}
+
+	private static class StableIdAssigner implements ManipulationListener {
+		private final String prefix;
+		private final List<GenericEntity> entities = new ArrayList<>();
+
+		private StableIdAssigner(String prefix) {
+			this.prefix = prefix;
+		}
+
+		@Override
+		public void noticeManipulation(Manipulation manipulation) {
+			if (manipulation.manipulationType() == ManipulationType.INSTANTIATION)
+				entities.add(((InstantiationManipulation) manipulation).getEntity());
+		}
+
+		private void assign() {
+			int index = 0;
+			for (GenericEntity entity : entities) {
+				if (entity.getId() != null)
+					continue;
+
+				String id = prefix + "." + index++;
+				entity.setId(id);
+				if (entity.getGlobalId() == null)
+					entity.setGlobalId(id);
+			}
 		}
 	}
 


### PR DESCRIPTION
Introduces canonical module/platform reflection, exposes it through RX contracts and platform diagnostics, and derives deterministic workbench initializer identities from artifact, space and bean context. Also fixes the marker-style RequestDecodingLenience annotation mapping for CX metadata loading.\n\nValidation: reflex platform tests and the downstream Proventem RX module test suite pass locally.