### PR TITLE
Honor configured Web API path in OpenAPI UI

### DIFF
--- a/openapi-v3-rx-module/src/hiconic/rx/openapi/v3/wire/space/OpenapiV3RxModuleSpace.java
+++ b/openapi-v3-rx-module/src/hiconic/rx/openapi/v3/wire/space/OpenapiV3RxModuleSpace.java
@@ -78,9 +78,9 @@ public class OpenapiV3RxModuleSpace implements RxModuleContract {
 		OpenapiUiServlet bean = new OpenapiUiServlet();
 		bean.setServiceDomains(serviceProcessing.serviceDomains());
 		bean.setAccessDomains(access.accessDomains());
+		bean.setWebApiPath(webApiServer.servletPath());
 
-		// TODO configure api and rest paths, once they are configurable
-		// bean.setWebApiPath("api");
+		// TODO configure the REST path once it is configurable
 		// bean.setRestPath("rest");
 
 		return bean;


### PR DESCRIPTION
The OpenAPI UI built its schema URL from the hard-coded api default, while the Web API servlet can be configured at paths such as api/v1. This caused Swagger UI to fetch a redirect/non-schema response and report a misleading YAML parser error. Wire the UI to WebApiServerContract.servletPath() so schema links and servlet registration share the same canonical configured endpoint path.

Verified with hc install for openapi-v3-rx-module.