### PR TITLE
Align RX OpenAPI with processor bindings

### DIFF
--- a/explorer-rx-module/src/hiconic/rx/explorer/processing/servlet/home/HomeRxServlet.java
+++ b/explorer-rx-module/src/hiconic/rx/explorer/processing/servlet/home/HomeRxServlet.java
@@ -329,24 +329,10 @@ public class HomeRxServlet extends BasicTemplateBasedServlet {
 		if (logApplicationAvailable.getAsBoolean())
 			runtimeStatus.getNestedLinks().add(
 					createLink("Log", relativeLogPath, "_self", null, "./webpages/images/cortex/logs.png"));
-		runtimeStatus.getNestedLinks()
-				.add(createLink("Deployment Summary", "./home?selectedTab=DEPLOYMENT SUMMARY&selectedTabPath=" + relativeDeploymentSummaryPath,
-						"_self", null, "./webpages/images/cortex/deploy.png"));
 		administrationGroup.getLinks().add(runtimeStatus);
 		// administrationGroup.getLinks().add(createLink("Logfiles",
 		// "./home?selectedTab=LOGS&selectedTabPath="+relativeLogPath, "_self", null,
 		// "./webpages/images/cortex/logs.png"));
-
-		LinkCollection setupgroup = LinkCollection.T.create();
-		setupgroup.setDisplayName("Platform Setup (Assets)");
-		setupgroup.setIconRef("./webpages/images/cortex/asset.png");
-
-		setupgroup.getNestedLinks().add(createLink("Administration", explorerUrlWithTrailingSlash + "?accessId=" + defaultUserSetupAccessId,
-				"tfControlCenter-setup", null, "./webpages/images/cortex/asset.png"));
-
-		configureAccessDomainLink(setupgroup, "setup");
-
-		administrationGroup.getLinks().add(setupgroup);
 
 		usergroups.getNestedLinks().add(createLink("Administration",
 				explorerUrlWithTrailingSlash + "?accessId=" + urlEncode(defaultAuthAccessId) + "#default", "tfControlCenter-auth", null));

--- a/openapi-v3-rx-module/pom.xml
+++ b/openapi-v3-rx-module/pom.xml
@@ -16,6 +16,11 @@
         </dependency>
         <dependency>
             <groupId>hiconic.platform.reflex</groupId>
+            <artifactId>service-processing-metadata-model</artifactId>
+            <version>${V.hiconic.platform.reflex}</version>
+        </dependency>
+        <dependency>
+            <groupId>hiconic.platform.reflex</groupId>
             <artifactId>openapi-v3-api-model</artifactId>
             <version>${V.hiconic.platform.reflex}</version>
         </dependency>

--- a/openapi-v3-rx-module/src/hiconic/rx/openapi/v3/processing/processor/export/ApiV1OpenapiProcessor.java
+++ b/openapi-v3-rx-module/src/hiconic/rx/openapi/v3/processing/processor/export/ApiV1OpenapiProcessor.java
@@ -62,6 +62,7 @@ import com.braintribe.utils.lcd.NullSafe;
 import hiconic.rx.module.api.service.ConfiguredModel;
 import hiconic.rx.module.api.service.ServiceDomain;
 import hiconic.rx.module.api.service.ServiceDomains;
+import hiconic.rx.model.service.processing.md.ProcessWith;
 import hiconic.rx.web.ddra.endpoints.api.v1.SingleDdraMapping;
 import hiconic.rx.web.ddra.endpoints.api.v1.SingleDdraMappingImpl;
 import hiconic.rx.web.ddra.endpoints.api.v1.WebApiMappingOracle;
@@ -145,6 +146,7 @@ public class ApiV1OpenapiProcessor extends AbstractOpenapiProcessor<OpenapiServi
 			List<EntityType<?>> requestTypes = modelEntities(sessionScopedContext) //
 					.filter(et -> !et.isAbstract()) //
 					.filter(et -> ServiceRequest.T.isAssignableFrom(et)) //
+					.filter(et -> processesRequest(sessionScopedContext, et)) //
 					.filter(et -> !ddraMapedTypes.contains(et.getTypeSignature())) //
 					.collect(Collectors.toList());
 
@@ -190,6 +192,10 @@ public class ApiV1OpenapiProcessor extends AbstractOpenapiProcessor<OpenapiServi
 				.map(gmModel -> modelNameToTag.get(gmModel.getName())) //
 				.filter(tag -> tag != null) //
 				.forEach(tag -> addNewTag(openApi, tag));
+	}
+
+	private boolean processesRequest(OpenapiContext context, EntityType<?> requestType) {
+		return context.getMetaData().entityType(requestType).meta(ProcessWith.T).exclusive() != null;
 	}
 
 	private String shortNameIfUniqueOrFullSignature(Map<String, List<EntityType<?>>> typesBySimpleName, EntityType<?> et) {

--- a/openapi-v3-rx-module/src/hiconic/rx/openapi/v3/wire/space/OpenapiV3RxModuleSpace.java
+++ b/openapi-v3-rx-module/src/hiconic/rx/openapi/v3/wire/space/OpenapiV3RxModuleSpace.java
@@ -1,6 +1,9 @@
 package hiconic.rx.openapi.v3.wire.space;
 
 import com.braintribe.gm._ServiceApiModel_;
+import com.braintribe.model.generic.reflection.Property;
+import com.braintribe.model.meta.data.prompt.Hidden;
+import com.braintribe.model.meta.selector.UseCaseSelector;
 import com.braintribe.model.openapi.v3_0.api.OpenapiEntitiesRequest;
 import com.braintribe.model.openapi.v3_0.api.OpenapiPropertiesRequest;
 import com.braintribe.model.openapi.v3_0.api.OpenapiServicesRequest;
@@ -25,6 +28,7 @@ import hiconic.rx.openapi.v3.processing.servlet.OpenapiUiServlet;
 import hiconic.rx.security.web.api.AuthFilters;
 import hiconic.rx.web.ddra.endpoints.api.WebApiServerContract;
 import hiconic.rx.web.server.api.WebServerContract;
+import hiconic.rx.webapi.endpoints.DdraEndpoint;
 import hiconic.rx.webapi.endpoints.api.v1.ApiV1DdraEndpoint;
 import jakarta.servlet.DispatcherType;
 
@@ -57,6 +61,19 @@ public class OpenapiV3RxModuleSpace implements RxModuleContract {
 		ModelConfiguration modelConfiguration = configurations.bySymbol(AbstractOpenapiProcessor.basicOpenapiProcessingModelRef);
 		modelConfiguration.addModel(_ServiceApiModel_.reflection);
 		modelConfiguration.addModel(ApiV1DdraEndpoint.T.getModel());
+		modelConfiguration.configureModel(editor -> {
+			UseCaseSelector simpleOpenapi = UseCaseSelector.T.create();
+			simpleOpenapi.setUseCase("openapi:simple");
+
+			Hidden hiddenInSimpleOpenapi = Hidden.T.create();
+			hiddenInSimpleOpenapi.setSelector(simpleOpenapi);
+
+			for (Property property : DdraEndpoint.T.getProperties())
+				editor.onEntityType(DdraEndpoint.T).addPropertyMetaData(property, hiddenInSimpleOpenapi);
+
+			for (Property property : ApiV1DdraEndpoint.T.getDeclaredProperties())
+				editor.onEntityType(ApiV1DdraEndpoint.T).addPropertyMetaData(property, hiddenInSimpleOpenapi);
+		});
 	}
 
 	@Override

--- a/reflex-platform-test/src/hiconic/rx/platform/service/ServiceDomainRoleGuardTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/service/ServiceDomainRoleGuardTest.java
@@ -19,6 +19,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.essential.UnsupportedOperation;
 import com.braintribe.gm.model.security.reason.Forbidden;
 import com.braintribe.model.resource.source.FileSystemSource;
 import com.braintribe.model.service.api.CompositeRequest;
@@ -77,6 +78,17 @@ public class ServiceDomainRoleGuardTest extends AbstractRxTest {
 
 		request.eval(platformContract.serviceProcessing().systemEvaluator()).getReasoned();
 		Assertions.assertThat(serviceDomains.listDomains(CompositeRequest.T)).containsExactlyElementsOf(domainsBefore);
+	}
+
+	@Test
+	public void explicitDomainReturnsReasonWhenRequestIsModeledButHasNoProcessor() {
+		GetResourcePayload request = GetResourcePayload.T.create();
+		request.setDomainId(PlatformTestDomains.resources.name());
+
+		Maybe<?> result = request.eval(evaluator).getReasoned();
+
+		Assertions.assertThat(result.isUnsatisfiedBy(UnsupportedOperation.T)).isTrue();
+		Assertions.assertThat(result.whyUnsatisfied().getText()).contains("No service processor mapped", GetResourcePayload.T.getTypeSignature());
 	}
 
 	private MulticastRequest multicastRequest() {

--- a/reflex-platform/src/hiconic/rx/platform/service/RxServiceDomainDispatcher.java
+++ b/reflex-platform/src/hiconic/rx/platform/service/RxServiceDomainDispatcher.java
@@ -130,6 +130,11 @@ public class RxServiceDomainDispatcher
 						.text("Service domain " + domainId + " does not support request " + requestType.getTypeSignature()) //
 						.toMaybe();
 
+			if (!domainProcessesRequest(serviceDomain, requestType))
+				return Reasons.build(UnsupportedOperation.T) //
+						.text("No service processor mapped for request " + requestType.getTypeSignature() + " in service domain " + domainId) //
+						.toMaybe();
+
 			// From this point on the evaluation context carries the canonical id, even if the request selected the domain through an alias.
 			domainId = serviceDomain.domainId();
 		}

--- a/web-api-server-rx-module/pom.xml
+++ b/web-api-server-rx-module/pom.xml
@@ -61,6 +61,11 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>hiconic.platform.reflex</groupId>
+            <artifactId>service-processing-metadata-model</artifactId>
+            <version>${V.hiconic.platform.reflex}</version>
+        </dependency>
+        <dependency>
+            <groupId>hiconic.platform.reflex</groupId>
             <artifactId>access-module-api</artifactId>
             <version>${V.hiconic.platform.reflex}</version>
         </dependency>

--- a/web-api-server-rx-module/src/hiconic/rx/web/ddra/mapping/StandardWebApiMappingOracle.java
+++ b/web-api-server-rx-module/src/hiconic/rx/web/ddra/mapping/StandardWebApiMappingOracle.java
@@ -54,6 +54,7 @@ import hiconic.rx.web.ddra.endpoints.api.WebApiMappingRegistry;
 import hiconic.rx.web.ddra.endpoints.api.v1.SingleDdraMapping;
 import hiconic.rx.web.ddra.endpoints.api.v1.SingleDdraMappingImpl;
 import hiconic.rx.web.ddra.endpoints.api.v1.WebApiMappingOracle;
+import hiconic.rx.model.service.processing.md.ProcessWith;
 import hiconic.rx.webapi.endpoints.OutputPrettiness;
 import hiconic.rx.webapi.endpoints.TypeExplicitness;
 import hiconic.rx.webapi.model.meta.BooleanOverride;
@@ -313,7 +314,14 @@ public class StandardWebApiMappingOracle implements WebApiMappingOracle, WebApiM
 					.getSubTypes() //
 					.transitive() //
 					.onlyInstantiable() //
-					.<EntityType<?>> asTypes();
+					.<EntityType<?>> asTypes() //
+					.stream() //
+					.filter(this::hasProcessorBinding) //
+					.collect(java.util.stream.Collectors.toSet());
+		}
+
+		private boolean hasProcessorBinding(EntityType<?> type) {
+			return cmdResolver.getMetaData().entityType(type).meta(ProcessWith.T).exclusive() != null;
 		}
 
 		private Set<EntityType<?>> ambiguousRequestTypes() {


### PR DESCRIPTION
Summary:
- advertise automatic DDRA and OpenAPI operations only when the selected service domain has an effective processor binding
- return a modeled UnsupportedOperation reason when an explicitly selected domain contains the request type but has no processor
- restore the simple OpenAPI masking of technical endpoint properties known from CX
- remove the obsolete Deployment Summary and Platform Setup asset links from the RX landing page

Verification:
- affected Reflex modules compile and install locally
- reflex-platform-test passes including the new missing-processor reason test
- proventem-rx-module-test compiles against the locally installed artifacts