### PR TITLE
Add platform initializer facility

### DIFF
--- a/db-rx-module/pom.xml
+++ b/db-rx-module/pom.xml
@@ -54,5 +54,20 @@ limitations under the License.
             <artifactId>db-configuration-model</artifactId>
             <version>${V.hiconic.platform.reflex}</version>
         </dependency>
+        <dependency>
+            <groupId>hiconic.platform.reflex</groupId>
+            <artifactId>cluster-module-api</artifactId>
+            <version>${V.hiconic.platform.reflex}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.braintribe.gm</groupId>
+            <artifactId>initializer-configuration-model</artifactId>
+            <version>${V.com.braintribe.gm}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.braintribe.gm</groupId>
+            <artifactId>initializer-manager-jdbc</artifactId>
+            <version>${V.com.braintribe.gm}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/db-rx-module/src/hiconic/rx/db/wire/space/DbRxModuleSpace.java
+++ b/db-rx-module/src/hiconic/rx/db/wire/space/DbRxModuleSpace.java
@@ -18,9 +18,12 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.initializer.jdbc.processing.GmDbInitializerManager;
+import com.braintribe.gm.initializer.model.configuration.InitializerDbConfiguration;
 import com.braintribe.model.generic.reflection.EntityType;
 import com.braintribe.wire.api.annotation.Import;
 import com.braintribe.wire.api.annotation.Managed;
+import com.braintribe.wire.api.context.WireContext;
 import com.braintribe.wire.api.scope.InstanceConfiguration;
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -28,6 +31,9 @@ import hiconic.rx.db.model.configuration.Database;
 import hiconic.rx.db.model.configuration.DatabaseConfiguration;
 import hiconic.rx.db.module.api.DatabaseContract;
 import hiconic.rx.db.processing.HikariDataSources;
+import hiconic.rx.initializer.api.InitializerBackend;
+import hiconic.rx.initializer.api.InitializerBackendContract;
+import hiconic.rx.locking.api.LockingContract;
 import hiconic.rx.module.api.wire.RxModuleContract;
 import hiconic.rx.module.api.wire.RxPlatformContract;
 
@@ -45,6 +51,14 @@ public class DbRxModuleSpace implements RxModuleContract, DatabaseContract {
 
 	@Import
 	private RxPlatformContract platform;
+
+	@Import
+	private WireContext<?> wireContext;
+
+	@Override
+	public void onDeploy() {
+		configureInitializerBackendIfRequested();
+	}
 
 	@Override
 	public DataSource findDataSource(String name) {
@@ -82,6 +96,29 @@ public class DbRxModuleSpace implements RxModuleContract, DatabaseContract {
 	@Override
 	public Maybe<DataSource> mainDataSource() {
 		return dataSource(DATABASE_NAME_MAIN);
+	}
+
+	private void configureInitializerBackendIfRequested() {
+		InitializerDbConfiguration configuration = platform.configuration().readConfig(InitializerDbConfiguration.T).get();
+		String databaseId = configuration.getDatabaseId();
+		if (databaseId == null || databaseId.isBlank())
+			return;
+
+		InitializerBackendContract initializerBackend = wireContext.findContract(InitializerBackendContract.class);
+		if (initializerBackend == null)
+			return;
+
+		LockingContract locking = wireContext.findContract(LockingContract.class);
+		if (locking == null)
+			throw new IllegalStateException("InitializerDbConfiguration requires an RX locking module");
+
+		GmDbInitializerManager manager = new GmDbInitializerManager();
+		manager.setUseCase("platform-initializers");
+		manager.setNodeId(platform.application().nodeId());
+		manager.setDataSource(dataSource(databaseId).get());
+		manager.setTasksTableName(configuration.getTasksTableName());
+		manager.setLocking(locking.locking());
+		initializerBackend.setBackend(InitializerBackend.of(manager, manager::runInitializers));
 	}
 
 }

--- a/reflex-module-api/pom.xml
+++ b/reflex-module-api/pom.xml
@@ -90,5 +90,10 @@ limitations under the License.
             <version>${V.hiconic.platform.reflex}</version>
             <?tag asset ?>
         </dependency>
+        <dependency>
+            <groupId>com.braintribe.gm</groupId>
+            <artifactId>initializer-manager-api</artifactId>
+            <version>${V.com.braintribe.gm}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/reflex-module-api/src/hiconic/rx/initializer/api/InitializerBackend.java
+++ b/reflex-module-api/src/hiconic/rx/initializer/api/InitializerBackend.java
@@ -1,0 +1,43 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.initializer.api;
+
+import com.braintribe.gm.initializer.api.InitializerFingerprintResolver;
+import com.braintribe.gm.initializer.api.InitializerRegistry;
+import com.braintribe.gm.initializer.api.InitializerTask;
+
+/** State and coordination backend used by the RX platform's initializer facility. */
+public interface InitializerBackend extends InitializerRegistry {
+
+	void runInitializers();
+
+	static InitializerBackend of(InitializerRegistry registry, Runnable execution) {
+		return new InitializerBackend() {
+			@Override
+			public void registerInitializer(String initializerName, InitializerFingerprintResolver fingerprintResolver, InitializerTask task) {
+				registry.registerInitializer(initializerName, fingerprintResolver, task);
+			}
+
+			@Override
+			public void ensureOrder(String runsFirstName, String runsLaterName) {
+				registry.ensureOrder(runsFirstName, runsLaterName);
+			}
+
+			@Override
+			public void runInitializers() {
+				execution.run();
+			}
+		};
+	}
+}

--- a/reflex-module-api/src/hiconic/rx/initializer/api/InitializerBackendContract.java
+++ b/reflex-module-api/src/hiconic/rx/initializer/api/InitializerBackendContract.java
@@ -1,0 +1,22 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.initializer.api;
+
+import hiconic.rx.module.api.wire.RxExportContract;
+
+/** Extension point for replacing the platform's default file-system initializer backend before application readiness. */
+public interface InitializerBackendContract extends RxExportContract {
+
+	void setBackend(InitializerBackend backend);
+}

--- a/reflex-module-api/src/hiconic/rx/initializer/api/InitializerContract.java
+++ b/reflex-module-api/src/hiconic/rx/initializer/api/InitializerContract.java
@@ -1,0 +1,24 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.initializer.api;
+
+import com.braintribe.gm.initializer.api.InitializerRegistry;
+
+import hiconic.rx.module.api.wire.RxExportContract;
+
+/** Application-wide registry for fingerprinted initialization tasks. */
+public interface InitializerContract extends RxExportContract {
+
+	InitializerRegistry registry();
+}

--- a/reflex-platform/pom.xml
+++ b/reflex-platform/pom.xml
@@ -145,5 +145,10 @@ limitations under the License.
             <artifactId>security-service-api-commons</artifactId>
             <version>${V.com.braintribe.gm}</version>
         </dependency>
+        <dependency>
+            <groupId>com.braintribe.gm</groupId>
+            <artifactId>initializer-manager-jdbc</artifactId>
+            <version>${V.com.braintribe.gm}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/reflex-platform/src/hiconic/rx/platform/module/wire/CoreRxPlatformModule.java
+++ b/reflex-platform/src/hiconic/rx/platform/module/wire/CoreRxPlatformModule.java
@@ -15,6 +15,8 @@ package hiconic.rx.platform.module.wire;
 
 import hiconic.rx.module.api.wire.RxModule;
 import hiconic.rx.module.api.wire.Exports;
+import hiconic.rx.initializer.api.InitializerBackendContract;
+import hiconic.rx.initializer.api.InitializerContract;
 import hiconic.rx.platform.module.wire.space.CoreRxPlatformModuleSpace;
 import hiconic.rx.push.api.PushContract;
 
@@ -25,6 +27,8 @@ public enum CoreRxPlatformModule implements RxModule<CoreRxPlatformModuleSpace> 
 	@Override
 	public void bindExports(Exports exports) {
 		exports.bind(PushContract.class, CoreRxPlatformModuleSpace.class);
+		exports.bind(InitializerContract.class, CoreRxPlatformModuleSpace.class);
+		exports.bind(InitializerBackendContract.class, CoreRxPlatformModuleSpace.class);
 	}
 
 }

--- a/reflex-platform/src/hiconic/rx/platform/module/wire/space/CoreRxPlatformModuleSpace.java
+++ b/reflex-platform/src/hiconic/rx/platform/module/wire/space/CoreRxPlatformModuleSpace.java
@@ -14,10 +14,13 @@
 package hiconic.rx.platform.module.wire.space;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
 import com.braintribe.gm.model.logging.level.api.LogLevelRequest;
+import com.braintribe.gm.initializer.api.InitializerRegistry;
+import com.braintribe.gm.initializer.jdbc.processing.FileSystemInitializerManager;
 import com.braintribe.gm.model.reason.Maybe;
 import com.braintribe.model.processing.service.api.ProcessorRegistry;
 import com.braintribe.model.processing.service.api.ServiceProcessor;
@@ -37,6 +40,9 @@ import com.braintribe.wire.api.annotation.Import;
 import com.braintribe.wire.api.annotation.Managed;
 
 import hiconic.rx.module.api.config.RxPlatformConfigurator;
+import hiconic.rx.initializer.api.InitializerBackend;
+import hiconic.rx.initializer.api.InitializerBackendContract;
+import hiconic.rx.initializer.api.InitializerContract;
 import hiconic.rx.module.api.resource.ResourceStorage;
 import hiconic.rx.module.api.service.ModelConfiguration;
 import hiconic.rx.module.api.service.ModelConfigurations;
@@ -46,6 +52,7 @@ import hiconic.rx.module.api.service.ServiceDomainConfigurations;
 import hiconic.rx.module.api.wire.RxModuleContract;
 import hiconic.rx.platform.processing.auth.RoleAuthorizationInterceptor;
 import hiconic.rx.platform.processing.cluster.SingleInstanceMulticastProcessor;
+import hiconic.rx.platform.processing.initializer.RxInitializerCoordinator;
 import hiconic.rx.platform.processing.push.PushChannelLifecycleHub;
 import hiconic.rx.platform.processing.push.PushProcessor;
 import hiconic.rx.platform.resource.FsResourceStorage;
@@ -63,7 +70,9 @@ import hiconic.rx.resource.model.configuration.ResourceStorageConfiguration;
  * Module that brings core ...
  */
 @Managed
-public class CoreRxPlatformModuleSpace implements RxModuleContract, PushContract {
+public class CoreRxPlatformModuleSpace implements RxModuleContract, PushContract, InitializerContract, InitializerBackendContract {
+
+	private static final String INITIALIZER_USE_CASE = "platform-initializers";
 
 	private static ModelSymbol internalDomainDefaultingApiModelSymbol = ModelSymbol.of("internal-domain-defaulting-api-model");
 	
@@ -234,6 +243,34 @@ public class CoreRxPlatformModuleSpace implements RxModuleContract, PushContract
 	@Override
 	public void onDeploy() {
 		configureResourceStorages();
+	}
+
+	@Override
+	public void onApplicationReady() {
+		initializerCoordinator().runInitializers();
+	}
+
+	@Override
+	public InitializerRegistry registry() {
+		return initializerCoordinator();
+	}
+
+	@Override
+	public void setBackend(InitializerBackend backend) {
+		initializerCoordinator().setBackend(backend);
+	}
+
+	@Managed
+	private RxInitializerCoordinator initializerCoordinator() {
+		return new RxInitializerCoordinator(fileSystemInitializerBackend());
+	}
+
+	private InitializerBackend fileSystemInitializerBackend() {
+		Path fingerprints = platform.applicationFiles().dataPath().resolve("initializers/platform-initializers.properties");
+		FileSystemInitializerManager manager = new FileSystemInitializerManager();
+		manager.setUseCase(INITIALIZER_USE_CASE);
+		manager.setTasksPropertiesFile(fingerprints.toFile());
+		return InitializerBackend.of(manager, manager::runInitializers);
 	}
 
 	private void configureResourceStorages() {

--- a/reflex-platform/src/hiconic/rx/platform/processing/initializer/RxInitializerCoordinator.java
+++ b/reflex-platform/src/hiconic/rx/platform/processing/initializer/RxInitializerCoordinator.java
@@ -1,0 +1,79 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.processing.initializer;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.braintribe.gm.initializer.api.InitializerFingerprintResolver;
+import com.braintribe.gm.initializer.api.InitializerRegistry;
+import com.braintribe.gm.initializer.api.InitializerTask;
+
+import hiconic.rx.initializer.api.InitializerBackend;
+
+/** Collects initializer registrations independently of the backend selected by the assembled application. */
+public class RxInitializerCoordinator implements InitializerRegistry {
+
+	private record TaskEntry(InitializerFingerprintResolver fingerprintResolver, InitializerTask task) {}
+	private record OrderEntry(String runsFirstName, String runsLaterName) {}
+
+	private final Map<String, TaskEntry> tasks = new LinkedHashMap<>();
+	private final Set<OrderEntry> orders = new LinkedHashSet<>();
+	private InitializerBackend backend;
+	private boolean backendExplicitlyConfigured;
+	private boolean runningOrFinished;
+
+	public RxInitializerCoordinator(InitializerBackend defaultBackend) {
+		backend = defaultBackend;
+	}
+
+	@Override
+	public synchronized void registerInitializer(String initializerName, InitializerFingerprintResolver fingerprintResolver, InitializerTask task) {
+		ensureRegistrationOpen();
+		TaskEntry previous = tasks.putIfAbsent(initializerName, new TaskEntry(fingerprintResolver, task));
+		if (previous != null)
+			throw new IllegalStateException("Initializer task already registered: " + initializerName);
+	}
+
+	@Override
+	public synchronized void ensureOrder(String runsFirstName, String runsLaterName) {
+		ensureRegistrationOpen();
+		orders.add(new OrderEntry(runsFirstName, runsLaterName));
+	}
+
+	public synchronized void setBackend(InitializerBackend backend) {
+		ensureRegistrationOpen();
+		if (backendExplicitlyConfigured)
+			throw new IllegalStateException("An initializer backend was already explicitly configured");
+		this.backend = backend;
+		backendExplicitlyConfigured = true;
+	}
+
+	public synchronized void runInitializers() {
+		if (runningOrFinished)
+			throw new IllegalStateException("RX initializers may only be run once");
+		runningOrFinished = true;
+
+		tasks.forEach((name, entry) -> backend.registerInitializer(name, entry.fingerprintResolver(), entry.task()));
+		orders.forEach(order -> backend.ensureOrder(order.runsFirstName(), order.runsLaterName()));
+		backend.runInitializers();
+	}
+
+	private void ensureRegistrationOpen() {
+		if (runningOrFinished)
+			throw new IllegalStateException("Initializer registration is closed because execution has already started");
+	}
+}


### PR DESCRIPTION
## Summary
- expose an application-wide initializer registry as an intrinsic RX platform service
- use the filesystem for fingerprints by default
- let db-rx-module switch to the JDBC initializer manager only when InitializerDbConfiguration declares a database
- preserve cluster coordination through the configured locking contract

## Verification
- hc install: reflex-module-api, reflex-platform, db-rx-module
- hc check-linking: reflex-platform, db-rx-module
- downstream Generali RX integration suite, including JDBC fingerprinting and persistence-identity preservation