### PR TITLE
Honor registered fallback processors in domain validation

### DIFF
--- a/reflex-platform-test/src/hiconic/rx/platform/service/ServiceDomainRoleGuardTest.java
+++ b/reflex-platform-test/src/hiconic/rx/platform/service/ServiceDomainRoleGuardTest.java
@@ -19,7 +19,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import com.braintribe.gm.model.reason.Maybe;
-import com.braintribe.gm.model.reason.essential.UnsupportedOperation;
 import com.braintribe.gm.model.security.reason.Forbidden;
 import com.braintribe.model.resource.source.FileSystemSource;
 import com.braintribe.model.service.api.CompositeRequest;
@@ -81,14 +80,17 @@ public class ServiceDomainRoleGuardTest extends AbstractRxTest {
 	}
 
 	@Test
-	public void explicitDomainReturnsReasonWhenRequestIsModeledButHasNoProcessor() {
+	public void resourcePayloadRequestsUsePlatformFallbackInExplicitDomains() {
 		GetResourcePayload request = GetResourcePayload.T.create();
 		request.setDomainId(PlatformTestDomains.resources.name());
+		FileSystemSource source = FileSystemSource.T.create();
+		source.setPath("non/existent");
+		request.setResourceSource(source);
 
 		Maybe<?> result = request.eval(evaluator).getReasoned();
 
-		Assertions.assertThat(result.isUnsatisfiedBy(UnsupportedOperation.T)).isTrue();
-		Assertions.assertThat(result.whyUnsatisfied().getText()).contains("No service processor mapped", GetResourcePayload.T.getTypeSignature());
+		Assertions.assertThat(result.isUnsatisfied()).isTrue();
+		Assertions.assertThat(result.whyUnsatisfied().getText()).doesNotContain("No service processor mapped");
 	}
 
 	private MulticastRequest multicastRequest() {

--- a/reflex-platform/src/hiconic/rx/platform/service/FallbackServiceProcessor.java
+++ b/reflex-platform/src/hiconic/rx/platform/service/FallbackServiceProcessor.java
@@ -1,0 +1,41 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.platform.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.processing.service.api.ServiceProcessor;
+import com.braintribe.model.processing.service.common.ConfigurableDispatchingServiceProcessor;
+import com.braintribe.model.service.api.ServiceRequest;
+
+/**
+ * The platform-wide fallback processor plus an exact reflection of the request types for which a fallback was registered.
+ * The domain dispatcher uses this information to distinguish supported fallback requests from genuinely unmapped requests.
+ */
+public class FallbackServiceProcessor extends ConfigurableDispatchingServiceProcessor {
+
+	private final List<EntityType<? extends ServiceRequest>> requestTypes = new ArrayList<>();
+
+	@Override
+	public <R extends ServiceRequest> void register(EntityType<R> requestType, ServiceProcessor<? super R, ?> serviceProcessor) {
+		super.register(requestType, serviceProcessor);
+		requestTypes.add(requestType);
+	}
+
+	public boolean supports(ServiceRequest request) {
+		return requestTypes.stream().anyMatch(type -> type.isInstance(request));
+	}
+}

--- a/reflex-platform/src/hiconic/rx/platform/service/RxServiceDomainDispatcher.java
+++ b/reflex-platform/src/hiconic/rx/platform/service/RxServiceDomainDispatcher.java
@@ -44,10 +44,16 @@ public class RxServiceDomainDispatcher
 	private static final Logger log = Logger.getLogger(RxServiceDomainDispatcher.class);
 
 	private ServiceDomains serviceDomains;
+	private FallbackServiceProcessor fallbackProcessor;
 
 	@Required
 	public void setServiceDomains(ServiceDomains serviceDomains) {
 		this.serviceDomains = serviceDomains;
+	}
+
+	@Required
+	public void setFallbackProcessor(FallbackServiceProcessor fallbackProcessor) {
+		this.fallbackProcessor = fallbackProcessor;
 	}
 
 	// ###################################################
@@ -110,7 +116,7 @@ public class RxServiceDomainDispatcher
 				// The domain index owns and shares this list across evaluations. Filtering it in place corrupts the index and races
 				// with concurrent requests (for example the browser's parallel session bootstrap calls).
 				dependers = dependers.stream() //
-						.filter(domain -> domainProcessesRequest(domain, requestType)) //
+						.filter(domain -> domainProcessesRequest(domain, request)) //
 						.toList();
 
 			if (dependers.size() != 1)
@@ -130,7 +136,7 @@ public class RxServiceDomainDispatcher
 						.text("Service domain " + domainId + " does not support request " + requestType.getTypeSignature()) //
 						.toMaybe();
 
-			if (!domainProcessesRequest(serviceDomain, requestType))
+			if (!domainProcessesRequest(serviceDomain, request))
 				return Reasons.build(UnsupportedOperation.T) //
 						.text("No service processor mapped for request " + requestType.getTypeSignature() + " in service domain " + domainId) //
 						.toMaybe();
@@ -148,14 +154,14 @@ public class RxServiceDomainDispatcher
 		return serviceRequest.domainId();
 	}
 
-	private boolean domainProcessesRequest(ServiceDomain domain, EntityType<? extends ServiceRequest> requestType) {
+	private boolean domainProcessesRequest(ServiceDomain domain, ServiceRequest request) {
 		ProcessWith processWith = domain.contextCmdResolver() //
 				.getMetaData() //
-				.entityType(requestType) //
+				.entityType(request.entityType()) //
 				.meta(ProcessWith.T) //
 				.exclusive();
 
-		return processWith != null;
+		return processWith != null || fallbackProcessor.supports(request);
 	}
 
 	private Maybe<? extends Object> wrongNumberOfDependers(List<? extends ServiceDomain> dependers,

--- a/reflex-platform/src/hiconic/rx/platform/wire/space/RxServiceProcessingSpace.java
+++ b/reflex-platform/src/hiconic/rx/platform/wire/space/RxServiceProcessingSpace.java
@@ -26,6 +26,7 @@ import hiconic.rx.module.api.wire.RxServiceProcessingContract;
 import hiconic.rx.module.api.service.ServiceProcessorRegistry;
 import hiconic.rx.platform.service.BasicServiceProcessorRegistry;
 import hiconic.rx.platform.service.ContextualizingServiceRequestEvaluator;
+import hiconic.rx.platform.service.FallbackServiceProcessor;
 import hiconic.rx.platform.service.RxServiceDomainDispatcher;
 import hiconic.rx.platform.service.RxServiceDomains;
 
@@ -99,12 +100,13 @@ public class RxServiceProcessingSpace implements RxServiceProcessingContract {
 	private RxServiceDomainDispatcher serviceDomainDispatcher() {
 		RxServiceDomainDispatcher bean = new RxServiceDomainDispatcher();
 		bean.setServiceDomains(serviceDomains());
+		bean.setFallbackProcessor(fallbackProcessor());
 		return bean;
 	}
 
 	@Managed
-	public ConfigurableDispatchingServiceProcessor fallbackProcessor() {
-		ConfigurableDispatchingServiceProcessor bean = new ConfigurableDispatchingServiceProcessor();
+	public FallbackServiceProcessor fallbackProcessor() {
+		FallbackServiceProcessor bean = new FallbackServiceProcessor();
 		return bean;
 	}
 


### PR DESCRIPTION
## Summary

- track the request types registered with the platform fallback processor
- let explicit service-domain validation accept only those registered fallback requests
- preserve the unsupported-operation result for genuinely unmapped requests
- cover resource-payload fallback routing with a platform integration test

## Verification

- hc test in reflex-platform-test
- hc test in dt1.proventem/proventem-rx-module-test (all 23 tests, including Workbench resource retrieval and ObjectStore payload storage)

This restores the intended ResourcePayloadProcessor fallback path which domain validation previously rejected before dispatch.