### PR TITLE
Run classpath configurators during RX bootstrap

### DIFF
--- a/reflex-platform/pom.xml
+++ b/reflex-platform/pom.xml
@@ -30,6 +30,11 @@ limitations under the License.
     </licenses>
     <dependencies>
         <dependency>
+            <groupId>com.braintribe.common</groupId>
+            <artifactId>configurator-api</artifactId>
+            <version>${V.com.braintribe.common}</version>
+        </dependency>
+        <dependency>
             <groupId>hiconic.platform.reflex</groupId>
             <artifactId>reflex-module-api</artifactId>
             <version>${V.hiconic.platform.reflex}</version>

--- a/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
+++ b/reflex-platform/src/hiconic/rx/platform/RxPlatform.java
@@ -38,6 +38,8 @@ import com.braintribe.codec.marshaller.yaml.YamlMarshaller;
 import com.braintribe.console.AbstractAnsiConsole;
 import com.braintribe.console.ConsoleConfiguration;
 import com.braintribe.console.ConsoleOutputs;
+import com.braintribe.config.configurator.ClasspathConfigurator;
+import com.braintribe.config.configurator.ConfiguratorContext;
 import com.braintribe.gm.config.yaml.index.ClasspathIndex;
 import com.braintribe.gm.model.reason.ReasonException;
 import com.braintribe.gm.model.reason.UnsatisfiedMaybeTunneling;
@@ -127,9 +129,16 @@ public class RxPlatform implements AutoCloseable {
 		// model reflection. Otherwise those early diagnostics escape through JUL's
 		// default ConsoleHandler even when the application disables console logging.
 		setupLogging();
+		runClasspathConfigurators();
 		propertyResolver = createPropertyResolver();
 
 		start();
+	}
+
+	private void runClasspathConfigurators() {
+		ConfiguratorContext context = new ConfiguratorContext("");
+		context.setMaster(true);
+		new ClasspathConfigurator(context).configure();
 	}
 
 	private ClasspathIndex createClasspathIndex() {


### PR DESCRIPTION
## Summary
- execute the established META-INF/.configurator mechanism during RX platform startup
- run configurators after logging initialization and before property/configuration loading
- provide a master ConfiguratorContext consistent with application bootstrap

## Verification
- reflex-platform compiles successfully
- git diff --check passes